### PR TITLE
Update indicators.yml.erb

### DIFF
--- a/jobs/loggr-syslog-agent/templates/indicators.yml.erb
+++ b/jobs/loggr-syslog-agent/templates/indicators.yml.erb
@@ -5,6 +5,7 @@ kind: IndicatorDocument
 metadata:
   labels:
     deployment: <%= spec.deployment %>
+    component: loggr-syslog-agent
 
 spec:
   product:


### PR DESCRIPTION
Adds a component metadata tag so that indicators from different jobs don't overwrite each other.