### PR TITLE
Enable override of the doppler addresses of the loggregator agent

### DIFF
--- a/jobs/loggregator_agent/spec
+++ b/jobs/loggregator_agent/spec
@@ -58,6 +58,10 @@ properties:
   doppler.grpc_port:
     description: Port for outgoing log messages via GRPC
     default: 8082
+  doppler.override_url:
+    description: "URL to use for dopplers instead of bosh link"
+  doppler.override_az_url:
+    description: "URL to use for dopplers AZ qualifies instead of using bosh links"
 
   loggregator.tls.ca_cert:
     description: "CA root required for key/cert verification"

--- a/jobs/loggregator_agent/templates/bpm.yml.erb
+++ b/jobs/loggregator_agent/templates/bpm.yml.erb
@@ -12,7 +12,12 @@ has_doppler = false
     router_addr = nil
     router_addr_with_az = nil
 
-    if_link("doppler") do |doppler|
+    if_p("doppler.override_url") do |addr|
+      router_addr = addr
+      if_p("doppler.override_az_url") do |azaddr|
+        router_addr_with_az = azaddr
+      end
+    end.else_if_link("doppler") do |doppler|
       router_addr = doppler.address(
         status: 'healthy',
       )

--- a/jobs/loggregator_agent_windows/monit
+++ b/jobs/loggregator_agent_windows/monit
@@ -13,8 +13,15 @@ end
     deployment = p("deployment").empty? ? spec.deployment : p("deployment")
     certs_dir = "/var/vcap/jobs/loggregator_agent_windows/config/certs"
 
-    router_addr = link("doppler").address
-    router_addr_with_az = link("doppler").address(azs: [spec.az])
+    if_p("doppler.override_url") do |addr|
+      router_addr = addr
+      if_p("doppler.override_az_url") do |azaddr|
+        router_addr_with_az = azaddr
+      end
+    end.else_if_link("doppler") do |doppler|
+      router_addr = doppler.address
+      router_addr_with_az = doppler.address(azs: [spec.az])
+    end
 
     tags = {
         deployment: deployment,

--- a/jobs/loggregator_agent_windows/spec
+++ b/jobs/loggregator_agent_windows/spec
@@ -80,6 +80,10 @@ properties:
   doppler.grpc_port:
     description: Port for outgoing log messages via GRPC
     default: 8082
+  doppler.override_url:
+    description: "URL to use for dopplers instead of bosh link"
+  doppler.override_az_url:
+    description: "URL to use for dopplers AZ qualifies instead of using bosh links"
 
   loggregator.tls.ca_cert:
     description: "CA root required for key/cert verification"


### PR DESCRIPTION
We would like to have the ability to override the use of the bosh-dns query language setting of the ROUTER_ADDR and ROUTER_AZ_URL.

This is so we can work with the loggregator agent when we have a different DNS provider than bosh-dns.

I'm not sure if the loggregator_agent_windows changes are good because this is not something we use.  Please feel free to give us the feedback there if it needs to be updated.