### PR TITLE
Allow for override of binding cache address from bosh-dns

### DIFF
--- a/jobs/loggr-syslog-agent-windows/monit
+++ b/jobs/loggr-syslog-agent-windows/monit
@@ -8,6 +8,11 @@
     drain_ca="#{certs_dir}/drain_ca.crt"
   }
 
+  cache_addr = b.address
+  if_p("binding_cache_override_url") do |addr|
+    cache_addr = addr
+  end
+
   process = {
     "name" => "syslog-agent",
     "executable" => "/var/vcap/packages/syslog-agent-windows/syslog-agent.exe",
@@ -17,7 +22,7 @@
       "CACHE_CERT_FILE_PATH" => "#{certs_dir}/cache_client.crt",
       "CACHE_KEY_FILE_PATH" => "#{certs_dir}/cache_client.key",
       "CACHE_COMMON_NAME" => p("cache.tls.cn"),
-      "CACHE_URL" => "https://#{b.address}:#{b.p("external_port")}",
+      "CACHE_URL" => "https://#{cache_addr}:#{b.p("external_port")}",
       "CACHE_POLLING_INTERVAL" => p("cache.polling_interval"),
 
       "AGENT_CA_FILE_PATH" => "#{certs_dir}/loggregator_ca.crt",

--- a/jobs/loggr-syslog-agent-windows/spec
+++ b/jobs/loggr-syslog-agent-windows/spec
@@ -28,6 +28,9 @@ properties:
     description: "Syslog agent is enabled on VM"
     default: true
 
+  binding_cache_override_url:
+    description: URL to use if required to override the default bosh-dns binding cache address
+
   port:
     description: "Port the agent is serving gRPC via mTLS"
     default: 3458

--- a/jobs/loggr-syslog-agent/spec
+++ b/jobs/loggr-syslog-agent/spec
@@ -29,6 +29,9 @@ properties:
     description: "Syslog agent is enabled on VM"
     default: true
 
+  binding_cache_override_url:
+    description: URL to use if required to override the default bosh-dns binding cache address
+
   port:
     description: "Port the agent is serving gRPC via mTLS"
     default: 3458

--- a/jobs/loggr-syslog-agent/templates/bpm.yml.erb
+++ b/jobs/loggr-syslog-agent/templates/bpm.yml.erb
@@ -45,7 +45,11 @@
     process["env"]["CACHE_CERT_FILE_PATH"] = "#{certs_dir}/cache_client.crt"
     process["env"]["CACHE_KEY_FILE_PATH"] = "#{certs_dir}/cache_client.key"
     process["env"]["CACHE_COMMON_NAME"] = "#{p("cache.tls.cn")}"
-    process["env"]["CACHE_URL"] = "https://#{binding.address}:#{binding.p("external_port")}"
+    cache_addr = binding.address
+    if_p("binding_cache_override_url") do |addr|
+      cache_addr = addr
+    end
+    process["env"]["CACHE_URL"] = "https://#{cache_addr}:#{binding.p("external_port")}"
     process["env"]["CACHE_POLLING_INTERVAL"] = "#{p("cache.polling_interval")}"
   end
 


### PR DESCRIPTION
The loggr_syslog_agent only sets the binding cache url through bosh-dns addresses.   We need the ability to set this using a bosh-dns alias which will be more consistent with the rest of the platform and enable use cases where we do not want to be limited by the bosh-dns addresses returned.

This is consistent with other compoents such as loggregator_agent which allows the override of the doppler addresses.