### PR TITLE
Allow override of cloud_controller API url

### DIFF
--- a/jobs/loggr-syslog-binding-cache/spec
+++ b/jobs/loggr-syslog-binding-cache/spec
@@ -51,6 +51,10 @@ properties:
       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384.
     default: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
 
+  api.override_url:
+    description: |
+      Use to override the default use of cloud_controller bosh link as the URL
+      most commonly change to cloud_controller_ng.service.cf.internal rather than the bosh specific address
   api.tls.ca_cert:
     description: |
       When the syslog communicates with the Cloud Controller it must

--- a/jobs/loggr-syslog-binding-cache/templates/bpm.yml.erb
+++ b/jobs/loggr-syslog-binding-cache/templates/bpm.yml.erb
@@ -1,5 +1,9 @@
 <%
   certs_dir =  "/var/vcap/jobs/loggr-syslog-binding-cache/config/certs"
+  api_url = link("cloud_controller").address
+  if_p("api.override_url") {
+    api_url = p("api.override_url")
+  }
   process = {
     "name" => "loggr-syslog-binding-cache",
     "executable" => "/var/vcap/packages/binding-cache/binding-cache",
@@ -8,7 +12,7 @@
       "API_CERT_FILE_PATH" => "#{certs_dir}/api_client.crt",
       "API_KEY_FILE_PATH" => "#{certs_dir}/api_client.key",
       "API_COMMON_NAME" => "#{p("api.tls.cn")}",
-      "API_URL" => "https://#{link("cloud_controller").address}:9023",
+      "API_URL" => "https://#{api_url}:9023",
       "API_POLLING_INTERVAL" => "#{p("api.polling_interval")}",
       "API_BATCH_SIZE" => "#{p("api.batch_size")}",
 


### PR DESCRIPTION
Need to be able to specify a service endpoint rather than relying on bosh links.  Similar to other PRs I have submitted regarding possibility to override URLs.