### PR TITLE
make debug port configurable

### DIFF
--- a/jobs/loggr-udp-forwarder/spec
+++ b/jobs/loggr-udp-forwarder/spec
@@ -37,6 +37,9 @@ properties:
     description: |
       The port to listen for incoming v1 (dropsonde) envelopes via UDP.
     default: 3457
+  debug_port:
+    description: "The port where the debug server will be listening."
+    default: 14830
   deployment:
     description: "Name of deployment (added as tag on all outgoing v2 envelopes)"
     default: ""

--- a/jobs/loggr-udp-forwarder/templates/bpm.yml.erb
+++ b/jobs/loggr-udp-forwarder/templates/bpm.yml.erb
@@ -14,6 +14,7 @@
         "LOGGREGATOR_AGENT_KEY_FILE_PATH" => "#{certs_dir}/loggregator_agent.key",
         "LOGGREGATOR_AGENT_ADDR" => "localhost:#{p('loggregator.ingress_port')}",
         "UDP_PORT" => "#{p('udp_port')}",
+        "DEBUG_PORT" => "#{p('debug_port')}",
         "DEPLOYMENT" => "#{deployment}",
         "JOB" => "#{job_name}",
         "INDEX" => "#{instance_id}",


### PR DESCRIPTION
* fixes this issue: https://github.com/cloudfoundry/loggregator-agent-release/issues/44
* [#178056975](https://www.pivotaltracker.com/story/show/178056975)


### Steps to reproduce
1. Deploy with the udp-forwarder on any VM
1. ssh onto that VM
1. run `netstat -tlpn | grep udp-forwarder`
1. see that ports 14829 and 14830 are being used
1. look at stderr.log and see that the debug endpoint is running on 14830.
1. run `monit restart loggr-udp-forwarder`
1. run `netstat -tlpn | grep udp-forwarder`
1. see that ports 14829 and 14830 are STILL being used
1. look at stderr.log and see that the debug endpoint is STILL running on 14830.
1. 🎉🎉🎉 