### PR TITLE
Make debug port configurable for loggr-system-metrics-agent

### DIFF
--- a/jobs/loggr-system-metrics-agent/spec
+++ b/jobs/loggr-system-metrics-agent/spec
@@ -19,6 +19,10 @@ properties:
     description: |
       Port where the /metrics endpoint is served
     default: 9100
+  debug_port:
+    description: |
+      Port where the /debug endpoint is served
+    default: 14922
 
   sample_interval:
     description: |

--- a/jobs/loggr-system-metrics-agent/templates/ctl.erb
+++ b/jobs/loggr-system-metrics-agent/templates/ctl.erb
@@ -30,6 +30,7 @@ case $1 in
 
     SAMPLE_INTERVAL=<%= p('sample_interval') %> \
     METRIC_PORT=<%= p('metrics_port') %> \
+    DEBUG_PORT=<%= p('debug_port') %> \
     DEPLOYMENT=<%= deployment %> \
     JOB=<%= job %> \
     INDEX=<%= index %> \


### PR DESCRIPTION
**Steps to reproduce**

1. Deploy with the loggr-system-metrics-agent on any VM
2. ssh onto that VM
3. run netstat -tlpn | grep system-metric
4. see that ports 9100 and 14922
6. run monit restart lloggr-system-metrics-agent
7. run netstat -tlpn | grep system-metric
8. see that ports 9100 and 14922 are STILL being used

🎉🎉🎉