### PR TITLE
Store aggregate drains on the binding cache

### DIFF
--- a/jobs/loggr-syslog-agent-windows/spec
+++ b/jobs/loggr-syslog-agent-windows/spec
@@ -48,7 +48,7 @@ properties:
       See https://www.openssl.org/docs/man1.1.0/apps/ciphers.html for a mapping of OpenSSL and RFC suite names.
 
   aggregate_drains:
-    description: "URLs to syslog drains that will receive all logs from all sources"
+    description: "DEPRECATED: Syslog server URLs that will receive the logs from all sources. Use binding cache instead if possible"
     default: ""
     example: "syslog-tls://some-drain-1,syslog-tls://some-drain-1"
 

--- a/jobs/loggr-syslog-agent/spec
+++ b/jobs/loggr-syslog-agent/spec
@@ -71,7 +71,7 @@ properties:
         - ECDHE-ECDSA-CHACHA20-POLY1305
 
   aggregate_drains:
-    description: "Syslog server URLs that will receive the logs from all sources"
+    description: "DEPRECATED: Syslog server URLs that will receive the logs from all sources. Use binding cache instead if possible"
     default: ""
     example: "syslog-tls://some-drain-1,syslog-tls://some-drain-1"
 

--- a/jobs/loggr-syslog-binding-cache/spec
+++ b/jobs/loggr-syslog-binding-cache/spec
@@ -32,6 +32,11 @@ properties:
     description: "Syslog binding cache is enabled on VM"
     default: true
 
+  aggregate_drains:
+    description: "Syslog server URLs that will receive the logs from all sources"
+    default: ""
+    example: "syslog-tls://some-drain-1,syslog-tls://some-drain-1"
+
   external_port:
     description: |
       The port where the cache serves bindings

--- a/jobs/loggr-syslog-binding-cache/templates/bpm.yml.erb
+++ b/jobs/loggr-syslog-binding-cache/templates/bpm.yml.erb
@@ -4,6 +4,10 @@
   if_p("api.override_url") {
     api_url = p("api.override_url")
   }
+  aggregate_drains=""
+  if_p("aggregate_drains") {
+    aggregate_drains = p("aggregate_drains")
+  }
   process = {
     "name" => "loggr-syslog-binding-cache",
     "executable" => "/var/vcap/packages/binding-cache/binding-cache",
@@ -15,6 +19,7 @@
       "API_URL" => "https://#{api_url}:9023",
       "API_POLLING_INTERVAL" => "#{p("api.polling_interval")}",
       "API_BATCH_SIZE" => "#{p("api.batch_size")}",
+      "AGGREGATE_DRAINS" => "#{aggregate_drains}",
 
       "CACHE_CA_FILE_PATH" => "#{certs_dir}/loggregator_ca.crt",
       "CACHE_CERT_FILE_PATH" => "#{certs_dir}/binding_cache.crt",

--- a/src/cmd/agent/main.go
+++ b/src/cmd/agent/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	_ "net/http/pprof"
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	rand.Seed(time.Now().UnixNano())
-	grpclog.SetLogger(log.New(ioutil.Discard, "", 0))
+	grpclog.SetLogger(log.New(io.Discard, "", 0))
 
 	config, err := app.LoadConfig()
 	if config.UseRFC3339 {

--- a/src/cmd/forwarder-agent/app/forwarder_agent.go
+++ b/src/cmd/forwarder-agent/app/forwarder_agent.go
@@ -1,14 +1,14 @@
 package app
 
 import (
-	"code.cloudfoundry.org/go-metric-registry"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"time"
+
+	metrics "code.cloudfoundry.org/go-metric-registry"
 
 	"net/http"
 
@@ -21,7 +21,7 @@ import (
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress"
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress/syslog"
 	egress_v2 "code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress/v2"
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/ingress/v2"
+	v2 "code.cloudfoundry.org/loggregator-agent-release/src/pkg/ingress/v2"
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/plumbing"
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/timeoutwaitgroup"
 	"google.golang.org/grpc"
@@ -162,7 +162,7 @@ func getDownstreamAddresses(glob string, l *log.Logger) []string {
 
 	var addrs []string
 	for _, f := range files {
-		yamlFile, err := ioutil.ReadFile(f)
+		yamlFile, err := os.ReadFile(f)
 		if err != nil {
 			l.Fatalf("cannot read file: %s", err)
 		}

--- a/src/cmd/forwarder-agent/app/forwarder_agent_test.go
+++ b/src/cmd/forwarder-agent/app/forwarder_agent_test.go
@@ -1,10 +1,8 @@
 package app_test
 
 import (
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/config"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -12,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/config"
 
 	"code.cloudfoundry.org/go-loggregator/v8"
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
@@ -369,7 +369,7 @@ func (s *spyLoggregatorV2BlockingIngress) BatchSender(srv loggregator_v2.Ingress
 }
 
 func forwarderPortConfigDir() string {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -378,7 +378,7 @@ func forwarderPortConfigDir() string {
 }
 
 func createForwarderPortConfigFile(port string) {
-	fDir, err := ioutil.TempDir(fConfigDir, "")
+	fDir, err := os.MkdirTemp(fConfigDir, "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -388,7 +388,7 @@ func createForwarderPortConfigFile(port string) {
 	Expect(err).ToNot(HaveOccurred())
 
 	contents := fmt.Sprintf(forwardConfigTemplate, port)
-	if err := ioutil.WriteFile(tmpfn, []byte(contents), 0666); err != nil {
+	if err := os.WriteFile(tmpfn, []byte(contents), 0666); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/src/cmd/prom-scraper/app/prom_scraper_test.go
+++ b/src/cmd/prom-scraper/app/prom_scraper_test.go
@@ -1,11 +1,7 @@
 package app_test
 
 import (
-	"code.cloudfoundry.org/loggregator-agent-release/src/cmd/prom-scraper/app"
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/scraper"
 	"fmt"
-	"github.com/onsi/gomega/gexec"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -14,6 +10,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"code.cloudfoundry.org/loggregator-agent-release/src/cmd/prom-scraper/app"
+	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/scraper"
+	"github.com/onsi/gomega/gexec"
 
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	metricsHelpers "code.cloudfoundry.org/go-metric-registry/testhelpers"
@@ -497,7 +497,7 @@ node2_counter 6
 )
 
 func metricPortConfigDir() string {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/cmd/syslog-agent/app/syslog_agent.go
+++ b/src/cmd/syslog-agent/app/syslog_agent.go
@@ -68,6 +68,7 @@ func NewSyslogAgent(
 		m,
 	)
 
+	var cacheClient *cache.CacheClient
 	var cupsFetcher binding.Fetcher = nil
 	if cfg.Cache.CAFile != "" {
 		tlsClient := plumbing.NewTLSHTTPClient(
@@ -77,7 +78,7 @@ func NewSyslogAgent(
 			cfg.Cache.CommonName,
 		)
 
-		cacheClient := cache.NewClient(cfg.Cache.URL, tlsClient)
+		cacheClient = cache.NewClient(cfg.Cache.URL, tlsClient)
 		cupsFetcher = bindings.NewFilteredBindingFetcher(
 			&cfg.Cache.Blacklist,
 			bindings.NewBindingFetcher(cfg.BindingsPerAppLimit, cacheClient, m),
@@ -87,7 +88,7 @@ func NewSyslogAgent(
 		cupsFetcher = bindings.NewDrainParamParser(cupsFetcher)
 	}
 
-	aggregateFetcher := bindings.NewAggregateDrainFetcher(cfg.AggregateDrainURLs)
+	aggregateFetcher := bindings.NewAggregateDrainFetcher(cfg.AggregateDrainURLs, cacheClient)
 	bindingManager := binding.NewManager(
 		cupsFetcher,
 		bindings.NewDrainParamParser(aggregateFetcher),

--- a/src/cmd/syslog-agent/app/syslog_agent.go
+++ b/src/cmd/syslog-agent/app/syslog_agent.go
@@ -4,8 +4,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"time"
 
 	gendiodes "code.cloudfoundry.org/go-diodes"
@@ -164,7 +164,7 @@ func trustedCertPool(trustedCAFile string) *x509.CertPool {
 	}
 
 	if trustedCAFile != "" {
-		cert, err := ioutil.ReadFile(trustedCAFile)
+		cert, err := os.ReadFile(trustedCAFile)
 		if err != nil {
 			log.Printf("unable to read provided custom CA: %s", err)
 			return cp

--- a/src/cmd/syslog-agent/app/syslog_agent_test.go
+++ b/src/cmd/syslog-agent/app/syslog_agent_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -618,7 +618,7 @@ func newSyslogHTTPSServer(syslogServerTestCerts *testhelper.TestCerts) *syslogHT
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		msg := &rfc5424.Message{}
 
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}

--- a/src/cmd/syslog-binding-cache/app/config.go
+++ b/src/cmd/syslog-binding-cache/app/config.go
@@ -1,9 +1,10 @@
 package app
 
 import (
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/config"
 	"log"
 	"time"
+
+	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/config"
 
 	envstruct "code.cloudfoundry.org/go-envstruct"
 )
@@ -19,6 +20,7 @@ type Config struct {
 	APIPollingInterval time.Duration `env:"API_POLLING_INTERVAL, report"`
 	APIBatchSize       int           `env:"API_BATCH_SIZE, report"`
 	CipherSuites       []string      `env:"CIPHER_SUITES, report"`
+	AggregateDrains    []string      `env:"AGGREGATE_DRAINS, report"`
 
 	CacheCAFile     string `env:"CACHE_CA_FILE_PATH,     required, report"`
 	CacheCertFile   string `env:"CACHE_CERT_FILE_PATH,   required, report"`

--- a/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
+++ b/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
@@ -3,7 +3,7 @@ package app_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -101,7 +101,7 @@ var _ = Describe("SyslogBindingCache", func() {
 
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 
 		var results []binding.Binding
@@ -137,7 +137,7 @@ var _ = Describe("SyslogBindingCache", func() {
 
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 
 		var result []binding.Binding

--- a/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
+++ b/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
@@ -1,7 +1,6 @@
 package app_test
 
 import (
-	"code.cloudfoundry.org/tlsconfig"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,6 +9,8 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"time"
+
+	"code.cloudfoundry.org/tlsconfig"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -64,6 +65,7 @@ var _ = Describe("SyslogBindingCache", func() {
 			CacheKeyFile:       bindingCacheTestCerts.Key("binding-cache"),
 			CacheCommonName:    "binding-cache",
 			CachePort:          cachePort,
+			AggregateDrains:    []string{"syslog://drain-e", "syslog://drain-f"},
 		}
 		sbc = app.NewSyslogBindingCache(config, metricsHelpers.NewMetricsRegistry(), logger)
 		go sbc.Run()
@@ -114,6 +116,36 @@ var _ = Describe("SyslogBindingCache", func() {
 		b = findBinding(results, "app-id-2")
 		Expect(b.Drains).To(ConsistOf("syslog://drain-c", "syslog://drain-d"))
 		Expect(b.Hostname).To(Equal("org.space.app-name-2"))
+	})
+
+	It("has an HTTP endpoint that returns aggregate drains", func() {
+		client := plumbing.NewTLSHTTPClient(
+			bindingCacheTestCerts.Cert("binding-cache"),
+			bindingCacheTestCerts.Key("binding-cache"),
+			bindingCacheTestCerts.CA(),
+			"binding-cache",
+		)
+
+		addr := fmt.Sprintf("https://localhost:%d/aggregate", cachePort)
+
+		var resp *http.Response
+		Eventually(func() error {
+			var err error
+			resp, err = client.Get(addr)
+			return err
+		}).Should(Succeed())
+
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		body, err := ioutil.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+
+		var result []binding.Binding
+		err = json.Unmarshal(body, &result)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(result).To(HaveLen(1))
+		Expect(result[0].Drains).To(ConsistOf("syslog://drain-e", "syslog://drain-f"))
 	})
 })
 

--- a/src/integration_tests/health_endpoint_test.go
+++ b/src/integration_tests/health_endpoint_test.go
@@ -1,11 +1,12 @@
 package agent_test
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+
 	"code.cloudfoundry.org/loggregator-agent-release/src/internal/testhelper"
 	"code.cloudfoundry.org/tlsconfig"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 
 	"code.cloudfoundry.org/loggregator-agent-release/src/internal/testservers"
 
@@ -35,7 +36,7 @@ var _ = Describe("Agent Health Endpoint", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer resp.Body.Close()
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(body).To(ContainSubstring("doppler_v1_streams"))

--- a/src/integration_tests/mock_server_test.go
+++ b/src/integration_tests/mock_server_test.go
@@ -1,9 +1,10 @@
 package agent_test
 
 import (
-	"code.cloudfoundry.org/tlsconfig"
 	"net"
 	"time"
+
+	"code.cloudfoundry.org/tlsconfig"
 
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"code.cloudfoundry.org/loggregator-agent-release/src/internal/testhelper"
@@ -31,7 +32,7 @@ func NewServer(testCerts *testhelper.TestCerts) (*Server, error) {
 	).Server(
 		tlsconfig.WithClientAuthenticationFromFile(testCerts.CA()),
 	)
-	
+
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/testhelper/bindata.go
+++ b/src/internal/testhelper/bindata.go
@@ -39,12 +39,12 @@ package testhelper
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -1542,36 +1542,36 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"binding-cache-ca.crl": bindingCacheCaCrl,
-	"binding-cache-ca.crt": bindingCacheCaCrt,
-	"binding-cache-ca.key": bindingCacheCaKey,
-	"capi-ca.crl": capiCaCrl,
-	"capi-ca.crt": capiCaCrt,
-	"capi-ca.key": capiCaKey,
-	"doppler.crt": dopplerCrt,
-	"doppler.csr": dopplerCsr,
-	"doppler.key": dopplerKey,
-	"forwarder.crt": forwarderCrt,
-	"forwarder.csr": forwarderCsr,
-	"forwarder.key": forwarderKey,
-	"loggregator-ca.crl": loggregatorCaCrl,
-	"loggregator-ca.crt": loggregatorCaCrt,
-	"loggregator-ca.key": loggregatorCaKey,
-	"metrics-scraper.crt": metricsScraperCrt,
-	"metrics-scraper.csr": metricsScraperCsr,
-	"metrics-scraper.key": metricsScraperKey,
-	"metron.crt": metronCrt,
-	"metron.csr": metronCsr,
-	"metron.key": metronKey,
-	"prom-scraper.crt": promScraperCrt,
-	"prom-scraper.csr": promScraperCsr,
-	"prom-scraper.key": promScraperKey,
-	"router.crt": routerCrt,
-	"router.csr": routerCsr,
-	"router.key": routerKey,
-	"syslog-agent.crt": syslogAgentCrt,
-	"syslog-agent.csr": syslogAgentCsr,
-	"syslog-agent.key": syslogAgentKey,
+	"binding-cache-ca.crl":        bindingCacheCaCrl,
+	"binding-cache-ca.crt":        bindingCacheCaCrt,
+	"binding-cache-ca.key":        bindingCacheCaKey,
+	"capi-ca.crl":                 capiCaCrl,
+	"capi-ca.crt":                 capiCaCrt,
+	"capi-ca.key":                 capiCaKey,
+	"doppler.crt":                 dopplerCrt,
+	"doppler.csr":                 dopplerCsr,
+	"doppler.key":                 dopplerKey,
+	"forwarder.crt":               forwarderCrt,
+	"forwarder.csr":               forwarderCsr,
+	"forwarder.key":               forwarderKey,
+	"loggregator-ca.crl":          loggregatorCaCrl,
+	"loggregator-ca.crt":          loggregatorCaCrt,
+	"loggregator-ca.key":          loggregatorCaKey,
+	"metrics-scraper.crt":         metricsScraperCrt,
+	"metrics-scraper.csr":         metricsScraperCsr,
+	"metrics-scraper.key":         metricsScraperKey,
+	"metron.crt":                  metronCrt,
+	"metron.csr":                  metronCsr,
+	"metron.key":                  metronKey,
+	"prom-scraper.crt":            promScraperCrt,
+	"prom-scraper.csr":            promScraperCsr,
+	"prom-scraper.key":            promScraperKey,
+	"router.crt":                  routerCrt,
+	"router.csr":                  routerCsr,
+	"router.key":                  routerKey,
+	"syslog-agent.crt":            syslogAgentCrt,
+	"syslog-agent.csr":            syslogAgentCsr,
+	"syslog-agent.key":            syslogAgentKey,
 	"system-metrics-agent-ca.crl": systemMetricsAgentCaCrl,
 	"system-metrics-agent-ca.crt": systemMetricsAgentCaCrt,
 	"system-metrics-agent-ca.key": systemMetricsAgentCaKey,
@@ -1616,37 +1616,38 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"binding-cache-ca.crl": &bintree{bindingCacheCaCrl, map[string]*bintree{}},
-	"binding-cache-ca.crt": &bintree{bindingCacheCaCrt, map[string]*bintree{}},
-	"binding-cache-ca.key": &bintree{bindingCacheCaKey, map[string]*bintree{}},
-	"capi-ca.crl": &bintree{capiCaCrl, map[string]*bintree{}},
-	"capi-ca.crt": &bintree{capiCaCrt, map[string]*bintree{}},
-	"capi-ca.key": &bintree{capiCaKey, map[string]*bintree{}},
-	"doppler.crt": &bintree{dopplerCrt, map[string]*bintree{}},
-	"doppler.csr": &bintree{dopplerCsr, map[string]*bintree{}},
-	"doppler.key": &bintree{dopplerKey, map[string]*bintree{}},
-	"forwarder.crt": &bintree{forwarderCrt, map[string]*bintree{}},
-	"forwarder.csr": &bintree{forwarderCsr, map[string]*bintree{}},
-	"forwarder.key": &bintree{forwarderKey, map[string]*bintree{}},
-	"loggregator-ca.crl": &bintree{loggregatorCaCrl, map[string]*bintree{}},
-	"loggregator-ca.crt": &bintree{loggregatorCaCrt, map[string]*bintree{}},
-	"loggregator-ca.key": &bintree{loggregatorCaKey, map[string]*bintree{}},
-	"metrics-scraper.crt": &bintree{metricsScraperCrt, map[string]*bintree{}},
-	"metrics-scraper.csr": &bintree{metricsScraperCsr, map[string]*bintree{}},
-	"metrics-scraper.key": &bintree{metricsScraperKey, map[string]*bintree{}},
-	"metron.crt": &bintree{metronCrt, map[string]*bintree{}},
-	"metron.csr": &bintree{metronCsr, map[string]*bintree{}},
-	"metron.key": &bintree{metronKey, map[string]*bintree{}},
-	"prom-scraper.crt": &bintree{promScraperCrt, map[string]*bintree{}},
-	"prom-scraper.csr": &bintree{promScraperCsr, map[string]*bintree{}},
-	"prom-scraper.key": &bintree{promScraperKey, map[string]*bintree{}},
-	"router.crt": &bintree{routerCrt, map[string]*bintree{}},
-	"router.csr": &bintree{routerCsr, map[string]*bintree{}},
-	"router.key": &bintree{routerKey, map[string]*bintree{}},
-	"syslog-agent.crt": &bintree{syslogAgentCrt, map[string]*bintree{}},
-	"syslog-agent.csr": &bintree{syslogAgentCsr, map[string]*bintree{}},
-	"syslog-agent.key": &bintree{syslogAgentKey, map[string]*bintree{}},
+	"binding-cache-ca.crl":        &bintree{bindingCacheCaCrl, map[string]*bintree{}},
+	"binding-cache-ca.crt":        &bintree{bindingCacheCaCrt, map[string]*bintree{}},
+	"binding-cache-ca.key":        &bintree{bindingCacheCaKey, map[string]*bintree{}},
+	"capi-ca.crl":                 &bintree{capiCaCrl, map[string]*bintree{}},
+	"capi-ca.crt":                 &bintree{capiCaCrt, map[string]*bintree{}},
+	"capi-ca.key":                 &bintree{capiCaKey, map[string]*bintree{}},
+	"doppler.crt":                 &bintree{dopplerCrt, map[string]*bintree{}},
+	"doppler.csr":                 &bintree{dopplerCsr, map[string]*bintree{}},
+	"doppler.key":                 &bintree{dopplerKey, map[string]*bintree{}},
+	"forwarder.crt":               &bintree{forwarderCrt, map[string]*bintree{}},
+	"forwarder.csr":               &bintree{forwarderCsr, map[string]*bintree{}},
+	"forwarder.key":               &bintree{forwarderKey, map[string]*bintree{}},
+	"loggregator-ca.crl":          &bintree{loggregatorCaCrl, map[string]*bintree{}},
+	"loggregator-ca.crt":          &bintree{loggregatorCaCrt, map[string]*bintree{}},
+	"loggregator-ca.key":          &bintree{loggregatorCaKey, map[string]*bintree{}},
+	"metrics-scraper.crt":         &bintree{metricsScraperCrt, map[string]*bintree{}},
+	"metrics-scraper.csr":         &bintree{metricsScraperCsr, map[string]*bintree{}},
+	"metrics-scraper.key":         &bintree{metricsScraperKey, map[string]*bintree{}},
+	"metron.crt":                  &bintree{metronCrt, map[string]*bintree{}},
+	"metron.csr":                  &bintree{metronCsr, map[string]*bintree{}},
+	"metron.key":                  &bintree{metronKey, map[string]*bintree{}},
+	"prom-scraper.crt":            &bintree{promScraperCrt, map[string]*bintree{}},
+	"prom-scraper.csr":            &bintree{promScraperCsr, map[string]*bintree{}},
+	"prom-scraper.key":            &bintree{promScraperKey, map[string]*bintree{}},
+	"router.crt":                  &bintree{routerCrt, map[string]*bintree{}},
+	"router.csr":                  &bintree{routerCsr, map[string]*bintree{}},
+	"router.key":                  &bintree{routerKey, map[string]*bintree{}},
+	"syslog-agent.crt":            &bintree{syslogAgentCrt, map[string]*bintree{}},
+	"syslog-agent.csr":            &bintree{syslogAgentCsr, map[string]*bintree{}},
+	"syslog-agent.key":            &bintree{syslogAgentKey, map[string]*bintree{}},
 	"system-metrics-agent-ca.crl": &bintree{systemMetricsAgentCaCrl, map[string]*bintree{}},
 	"system-metrics-agent-ca.crt": &bintree{systemMetricsAgentCaCrt, map[string]*bintree{}},
 	"system-metrics-agent-ca.key": &bintree{systemMetricsAgentCaKey, map[string]*bintree{}},
@@ -1666,7 +1667,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}
@@ -1698,4 +1699,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/src/internal/testhelper/certificate.go
+++ b/src/internal/testhelper/certificate.go
@@ -1,9 +1,10 @@
 package testhelper
 
 import (
-	"code.cloudfoundry.org/tlsconfig/certtest"
-	"io/ioutil"
 	"log"
+	"os"
+
+	"code.cloudfoundry.org/tlsconfig/certtest"
 )
 
 type TestCerts struct {
@@ -67,7 +68,7 @@ func generateCA(caName string) (*certtest.Authority, string) {
 }
 
 func tmpFile(prefix string, caBytes []byte) string {
-	file, err := ioutil.TempFile("", prefix)
+	file, err := os.CreateTemp("", prefix)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/pkg/binding/manager.go
+++ b/src/pkg/binding/manager.go
@@ -201,6 +201,7 @@ func (m *Manager) resetAggregateDrains() {
 	var aggregateDrains []drainHolder
 	bindings, err := m.aggregateDrainFetcher.FetchBindings()
 	if err != nil {
+		m.log.Printf("failed to connect to cache for aggregate drains: %s", err)
 		return
 	}
 

--- a/src/pkg/binding/poller_test.go
+++ b/src/pkg/binding/poller_test.go
@@ -2,14 +2,15 @@ package binding_test
 
 import (
 	"bytes"
-	metricsHelpers "code.cloudfoundry.org/go-metric-registry/testhelpers"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"sync/atomic"
 	"time"
+
+	metricsHelpers "code.cloudfoundry.org/go-metric-registry/testhelpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -167,7 +168,7 @@ func (c *fakeAPIClient) Get(nextID int) (*http.Response, error) {
 	b, err := json.Marshal(&binding)
 	Expect(err).ToNot(HaveOccurred())
 	resp := &http.Response{
-		Body: ioutil.NopCloser(bytes.NewReader(b)),
+		Body: io.NopCloser(bytes.NewReader(b)),
 	}
 
 	return resp, nil

--- a/src/pkg/binding/store.go
+++ b/src/pkg/binding/store.go
@@ -1,8 +1,9 @@
 package binding
 
 import (
-	"code.cloudfoundry.org/go-metric-registry"
 	"sync"
+
+	metrics "code.cloudfoundry.org/go-metric-registry"
 )
 
 type Store struct {
@@ -36,4 +37,17 @@ func (s *Store) Set(bindings []Binding) {
 	s.bindings = bindings
 	s.bindingCount.Set(float64(len(s.bindings)))
 	s.mu.Unlock()
+}
+
+type AggregateStore struct {
+	AggregateDrains []string
+}
+
+func (store *AggregateStore) Get() []Binding {
+	return []Binding{
+		{
+			AppID:  "",
+			Drains: store.AggregateDrains,
+		},
+	}
 }

--- a/src/pkg/cache/client.go
+++ b/src/pkg/cache/client.go
@@ -10,8 +10,6 @@ import (
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/binding"
 )
 
-var pathTemplate = "%s/bindings"
-
 type httpGetter interface {
 	Get(string) (*http.Response, error)
 }
@@ -29,8 +27,16 @@ func NewClient(cacheAddr string, h httpGetter) *CacheClient {
 }
 
 func (c *CacheClient) Get() ([]binding.Binding, error) {
+	return c.get("bindings")
+}
+
+func (c *CacheClient) GetAggregate() ([]binding.Binding, error) {
+	return c.get("aggregate")
+}
+
+func (c *CacheClient) get(path string) ([]binding.Binding, error) {
 	var bindings []binding.Binding
-	resp, err := c.h.Get(fmt.Sprintf(pathTemplate, c.cacheAddr))
+	resp, err := c.h.Get(fmt.Sprintf("%s/"+path, c.cacheAddr))
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/cache/client.go
+++ b/src/pkg/cache/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/binding"
@@ -41,7 +40,7 @@ func (c *CacheClient) get(path string) ([]binding.Binding, error) {
 		return nil, err
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}()
 

--- a/src/pkg/cache/client_test.go
+++ b/src/pkg/cache/client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -41,7 +41,7 @@ var _ = Describe("Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		spyHTTPClient.response = &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(bytes.NewReader(j)),
+			Body:       io.NopCloser(bytes.NewReader(j)),
 		}
 
 		Expect(client.Get()).To(Equal(bindings))
@@ -61,7 +61,7 @@ var _ = Describe("Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		spyHTTPClient.response = &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(bytes.NewReader(j)),
+			Body:       io.NopCloser(bytes.NewReader(j)),
 		}
 
 		Expect(client.GetAggregate()).To(Equal(bindings))
@@ -83,7 +83,7 @@ var _ = Describe("Client", func() {
 	It("returns empty bindings if cache returns a non-OK status code", func() {
 		spyHTTPClient.response = &http.Response{
 			StatusCode: http.StatusInternalServerError,
-			Body:       ioutil.NopCloser(strings.NewReader("")),
+			Body:       io.NopCloser(strings.NewReader("")),
 		}
 
 		_, err := client.Get()

--- a/src/pkg/clientpool/v1/grpc_connector_test.go
+++ b/src/pkg/clientpool/v1/grpc_connector_test.go
@@ -3,10 +3,9 @@ package v1_test
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/clientpool/v1"
+	v1 "code.cloudfoundry.org/loggregator-agent-release/src/pkg/clientpool/v1"
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/plumbing"
 
 	. "github.com/onsi/ginkgo"
@@ -45,7 +44,7 @@ var _ = Describe("GRPCConnector", func() {
 				})),
 			}
 			fetcher = &SpyFetcher{
-				Closer: ioutil.NopCloser(nil),
+				Closer: io.NopCloser(nil),
 				Client: SpyStream{},
 			}
 			connector = v1.MakeGRPCConnector(fetcher, balancers)
@@ -76,7 +75,7 @@ var _ = Describe("GRPCConnector", func() {
 				})),
 			}
 			fetcher := &SpyFetcher{
-				Closer: ioutil.NopCloser(nil),
+				Closer: io.NopCloser(nil),
 				Client: SpyStream{},
 			}
 			connector := v1.MakeGRPCConnector(fetcher, balancers)
@@ -97,7 +96,7 @@ var _ = Describe("GRPCConnector", func() {
 				})),
 			}
 			fetcher := &SpyFetcher{
-				Closer: ioutil.NopCloser(nil),
+				Closer: io.NopCloser(nil),
 				Client: SpyStream{},
 			}
 			connector := v1.MakeGRPCConnector(fetcher, balancers)

--- a/src/pkg/clientpool/v1/pusher_fetcher.go
+++ b/src/pkg/clientpool/v1/pusher_fetcher.go
@@ -1,11 +1,12 @@
 package v1
 
 import (
-	"code.cloudfoundry.org/go-metric-registry"
 	"context"
 	"fmt"
 	"io"
 	"log"
+
+	metrics "code.cloudfoundry.org/go-metric-registry"
 
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/plumbing"
 
@@ -13,7 +14,7 @@ import (
 )
 
 type MetricClient interface {
-	NewGauge(name, helpText string,  opts ...metrics.MetricOption) metrics.Gauge
+	NewGauge(name, helpText string, opts ...metrics.MetricOption) metrics.Gauge
 }
 
 type PusherFetcher struct {
@@ -37,8 +38,8 @@ func NewPusherFetcher(mc MetricClient, opts ...grpc.DialOption) *PusherFetcher {
 
 	return &PusherFetcher{
 		opts:               opts,
-		dopplerConnections: func(i float64){ dopplerConnections.Add(i) },
-		dopplerV1Streams:   func(i float64){ dopplerV1Streams.Add(i) },
+		dopplerConnections: func(i float64) { dopplerConnections.Add(i) },
+		dopplerV1Streams:   func(i float64) { dopplerV1Streams.Add(i) },
 	}
 }
 

--- a/src/pkg/clientpool/v2/grpc_connector_test.go
+++ b/src/pkg/clientpool/v2/grpc_connector_test.go
@@ -3,11 +3,10 @@ package v2_test
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/clientpool/v2"
+	v2 "code.cloudfoundry.org/loggregator-agent-release/src/pkg/clientpool/v2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -47,7 +46,7 @@ var _ = Describe("GRPCConnector", func() {
 				})),
 			}
 			fetcher = &SpyFetcher{
-				Closer: ioutil.NopCloser(nil),
+				Closer: io.NopCloser(nil),
 				Client: SpyStream{},
 			}
 			connector = v2.MakeGRPCConnector(fetcher, balancers)
@@ -78,7 +77,7 @@ var _ = Describe("GRPCConnector", func() {
 				})),
 			}
 			fetcher := &SpyFetcher{
-				Closer: ioutil.NopCloser(nil),
+				Closer: io.NopCloser(nil),
 				Client: SpyStream{},
 			}
 			connector := v2.MakeGRPCConnector(fetcher, balancers)
@@ -99,7 +98,7 @@ var _ = Describe("GRPCConnector", func() {
 				})),
 			}
 			fetcher := &SpyFetcher{
-				Closer: ioutil.NopCloser(nil),
+				Closer: io.NopCloser(nil),
 				Client: SpyStream{},
 			}
 			connector := v2.MakeGRPCConnector(fetcher, balancers)

--- a/src/pkg/clientpool/v2/sender_fetcher.go
+++ b/src/pkg/clientpool/v2/sender_fetcher.go
@@ -1,11 +1,12 @@
 package v2
 
 import (
-	"code.cloudfoundry.org/go-metric-registry"
 	"context"
 	"fmt"
 	"io"
 	"log"
+
+	metrics "code.cloudfoundry.org/go-metric-registry"
 
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"google.golang.org/grpc"
@@ -37,7 +38,7 @@ func NewSenderFetcher(mc MetricClient, opts ...grpc.DialOption) *SenderFetcher {
 	fetcher := SenderFetcher{
 		opts:               opts,
 		dopplerConnections: func(i float64) { dopplerConnections.Add(i) },
-		dopplerV2Streams:  func(i float64)  { dopplerV2Streams.Add(i) },
+		dopplerV2Streams:   func(i float64) { dopplerV2Streams.Add(i) },
 	}
 	return &fetcher
 }

--- a/src/pkg/clientpool/v2/sender_fetcher_test.go
+++ b/src/pkg/clientpool/v2/sender_fetcher_test.go
@@ -4,9 +4,9 @@ import (
 	"io"
 	"net"
 
-	metricsHelpers "code.cloudfoundry.org/go-metric-registry/testhelpers"
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/clientpool/v2"
+	metricsHelpers "code.cloudfoundry.org/go-metric-registry/testhelpers"
+	v2 "code.cloudfoundry.org/loggregator-agent-release/src/pkg/clientpool/v2"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 

--- a/src/pkg/egress/syslog/envelope_writer.go
+++ b/src/pkg/egress/syslog/envelope_writer.go
@@ -1,10 +1,11 @@
 package syslog
 
 import (
-	"code.cloudfoundry.org/go-metric-registry"
-	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress"
 	"log"
+
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
+	metrics "code.cloudfoundry.org/go-metric-registry"
+	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress"
 )
 
 type drainGetter func(sourceID string) []egress.Writer

--- a/src/pkg/egress/syslog/filtering_drain_writer_test.go
+++ b/src/pkg/egress/syslog/filtering_drain_writer_test.go
@@ -1,16 +1,17 @@
 package syslog_test
 
-import(
+import (
+	"time"
+
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress/syslog"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"time"
 )
 
 var _ = Describe("Filtering Drain Writer", func() {
-	It("filters all envelope types except log", func(){
+	It("filters all envelope types except log", func() {
 		binding := syslog.Binding{AppId: "app-1", Hostname: "host-1", Drain: "syslog://drain.url.com", Type: syslog.BINDING_TYPE_LOG}
 		fakeWriter := &fakeWriter{}
 
@@ -29,9 +30,9 @@ var _ = Describe("Filtering Drain Writer", func() {
 			SourceId:  "app-1",
 			Message: &loggregator_v2.Envelope_Counter{
 				Counter: &loggregator_v2.Counter{
-					Name:                 "some-counter",
-					Delta:                1,
-					Total:                10,
+					Name:  "some-counter",
+					Delta: 1,
+					Total: 10,
 				},
 			},
 		}
@@ -65,9 +66,9 @@ var _ = Describe("Filtering Drain Writer", func() {
 			SourceId:  "app-1",
 			Message: &loggregator_v2.Envelope_Counter{
 				Counter: &loggregator_v2.Counter{
-					Name:                 "some-counter",
-					Delta:                1,
-					Total:                10,
+					Name:  "some-counter",
+					Delta: 1,
+					Total: 10,
 				},
 			},
 		}
@@ -111,9 +112,9 @@ var _ = Describe("Filtering Drain Writer", func() {
 			SourceId:  "app-1",
 			Message: &loggregator_v2.Envelope_Counter{
 				Counter: &loggregator_v2.Counter{
-					Name:                 "some-counter",
-					Delta:                1,
-					Total:                10,
+					Name:  "some-counter",
+					Delta: 1,
+					Total: 10,
 				},
 			},
 		}
@@ -164,7 +165,6 @@ var _ = Describe("Filtering Drain Writer", func() {
 		)
 	})
 
-
 	It("errors on invalid binding type", func() {
 		binding := syslog.Binding{AppId: "app-1", Hostname: "host-1", Drain: "syslog://drain.url.com", Type: 10}
 		_, err := syslog.NewFilteringDrainWriter(binding, &fakeWriter{})
@@ -176,7 +176,7 @@ type fakeWriter struct {
 	envs []*loggregator_v2.Envelope
 }
 
-func(f *fakeWriter) Write(env *loggregator_v2.Envelope) error {
+func (f *fakeWriter) Write(env *loggregator_v2.Envelope) error {
 	f.envs = append(f.envs, env)
 	return nil
 }

--- a/src/pkg/egress/syslog/https_test.go
+++ b/src/pkg/egress/syslog/https_test.go
@@ -2,7 +2,7 @@ package syslog_test
 
 import (
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -337,7 +337,7 @@ func newMockDrain(status int) *SpyDrain {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		message := &rfc5424.Message{}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		Expect(err).ToNot(HaveOccurred())
 		defer r.Body.Close()
 

--- a/src/pkg/egress/v1/event_marshaller_test.go
+++ b/src/pkg/egress/v1/event_marshaller_test.go
@@ -77,7 +77,7 @@ var _ = Describe("EventMarshaller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(mockChainWriter.WriteInput.Message).To(Receive(Equal(expected)))
 
-				metric := metricClient.GetMetric("egress", map[string]string{"metric_version":"1.0"})
+				metric := metricClient.GetMetric("egress", map[string]string{"metric_version": "1.0"})
 				Expect(metric.Value()).To(Equal(float64(1)))
 			})
 		})

--- a/src/pkg/egress/v2/counter_aggregator.go
+++ b/src/pkg/egress/v2/counter_aggregator.go
@@ -11,13 +11,13 @@ type counterID struct {
 
 type CounterAggregator struct {
 	counterTotals map[counterID]uint64
-	processor func(env *loggregator_v2.Envelope)
+	processor     func(env *loggregator_v2.Envelope)
 }
 
 func NewCounterAggregator(processor func(env *loggregator_v2.Envelope)) *CounterAggregator {
 	return &CounterAggregator{
 		counterTotals: make(map[counterID]uint64),
-		processor:        processor,
+		processor:     processor,
 	}
 }
 

--- a/src/pkg/egress/v2/counter_aggregator_test.go
+++ b/src/pkg/egress/v2/counter_aggregator_test.go
@@ -1,9 +1,10 @@
 package v2_test
 
 import (
+	"fmt"
+
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	egress "code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress/v2"
-	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -11,7 +12,7 @@ import (
 var _ = Describe("CounterAggregator", func() {
 	tagger := egress.NewTagger(nil)
 
-	It("calculates separate totals for envelopes with deprecated defaultTags", func( ){
+	It("calculates separate totals for envelopes with deprecated defaultTags", func() {
 		tagger := egress.NewTagger(nil)
 
 		aggregator := egress.NewCounterAggregator(tagger.TagEnvelope)

--- a/src/pkg/egress/v2/envelope_writer.go
+++ b/src/pkg/egress/v2/envelope_writer.go
@@ -11,13 +11,13 @@ type EnvelopeProcessor interface {
 }
 
 type EnvelopeWriter struct {
-	writer     Writer
+	writer    Writer
 	processor EnvelopeProcessor
 }
 
 func NewEnvelopeWriter(w Writer, ps EnvelopeProcessor) EnvelopeWriter {
 	return EnvelopeWriter{
-		writer:     w,
+		writer:    w,
 		processor: ps,
 	}
 }

--- a/src/pkg/egress/v2/timer_tag_filterer.go
+++ b/src/pkg/egress/v2/timer_tag_filterer.go
@@ -25,7 +25,7 @@ func (t TimerTagFilterer) Filter(env *loggregator_v2.Envelope) {
 	}
 
 	for tag := range env.GetTags() {
-		if ! t.whitelisted(tag) {
+		if !t.whitelisted(tag) {
 			delete(env.Tags, tag)
 		}
 	}

--- a/src/pkg/egress/v2/transponder_test.go
+++ b/src/pkg/egress/v2/transponder_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"time"
 
-	metricsHelpers "code.cloudfoundry.org/go-metric-registry/testhelpers"
 	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
+	metricsHelpers "code.cloudfoundry.org/go-metric-registry/testhelpers"
 	egress "code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress/v2"
 
 	. "github.com/onsi/ginkgo"
@@ -113,8 +113,8 @@ var _ = Describe("Transponder", func() {
 			tx := egress.NewTransponder(nexter, writer, 5, time.Minute, spy)
 			go tx.Start()
 
-			Eventually(hasMetric(spy, "egress", map[string]string{"metric_version":"2.0"}))
-			Eventually(hasMetric(spy, "dropped", map[string]string{"direction":"egress","metric_version":"2.0"}))
+			Eventually(hasMetric(spy, "egress", map[string]string{"metric_version": "2.0"}))
+			Eventually(hasMetric(spy, "dropped", map[string]string{"direction": "egress", "metric_version": "2.0"}))
 
 		})
 	})
@@ -125,4 +125,3 @@ func hasMetric(mc *metricsHelpers.SpyMetricsRegistry, metricName string, tags ma
 		return mc.HasMetric(metricName, tags)
 	}
 }
-

--- a/src/pkg/ingress/bindings/aggregate_fetcher.go
+++ b/src/pkg/ingress/bindings/aggregate_fetcher.go
@@ -25,9 +25,9 @@ func NewAggregateDrainFetcher(bindings []string, cf CacheFetcher) *AggregateDrai
 
 func (a *AggregateDrainFetcher) FetchBindings() ([]syslog.Binding, error) {
 	if len(a.bindings) != 0 {
-		var bindingSlice []syslog.Binding
-		bindingSlice = append(bindingSlice, a.bindings...)
-		return bindingSlice, nil
+		var bindings []syslog.Binding
+		bindings = append(bindings, a.bindings...)
+		return bindings, nil
 	} else if a.cf != nil {
 		aggregate, err := a.cf.GetAggregate()
 		if err != nil {

--- a/src/pkg/ingress/bindings/aggregate_fetcher_test.go
+++ b/src/pkg/ingress/bindings/aggregate_fetcher_test.go
@@ -1,6 +1,9 @@
 package bindings_test
 
 import (
+	"errors"
+
+	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/binding"
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress/syslog"
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/ingress/bindings"
 	. "github.com/onsi/ginkgo"
@@ -13,56 +16,126 @@ var _ = Describe("Aggregate Drain Binding Fetcher", func() {
 	BeforeEach(func() {
 	})
 
-	It("returns drain bindings for the drain urls", func() {
-		bs := []string{
-			"syslog://aggregate-drain1.url.com",
-			"syslog://aggregate-drain2.url.com?include-metrics-deprecated=true",
-		}
-		fetcher := bindings.NewAggregateDrainFetcher(bs)
+	Context("cache fetcher is nil", func() {
+		It("returns drain bindings for the drain urls", func() {
+			bs := []string{
+				"syslog://aggregate-drain1.url.com",
+				"syslog://aggregate-drain2.url.com?include-metrics-deprecated=true",
+			}
+			fetcher := bindings.NewAggregateDrainFetcher(bs, nil)
 
-		b, err := fetcher.FetchBindings()
-		Expect(err).ToNot(HaveOccurred())
+			b, err := fetcher.FetchBindings()
+			Expect(err).ToNot(HaveOccurred())
 
-		Expect(b).To(ConsistOf(
-			syslog.Binding{
-				AppId: "",
-				Drain: "syslog://aggregate-drain1.url.com",
-				Type:  syslog.BINDING_TYPE_LOG,
-			},
-			syslog.Binding{
-				AppId: "",
-				Drain: "syslog://aggregate-drain2.url.com?include-metrics-deprecated=true",
-				Type:  syslog.BINDING_TYPE_AGGREGATE,
-			},
-		))
+			Expect(b).To(ConsistOf(
+				syslog.Binding{
+					AppId: "",
+					Drain: "syslog://aggregate-drain1.url.com",
+					Type:  syslog.BINDING_TYPE_LOG,
+				},
+				syslog.Binding{
+					AppId: "",
+					Drain: "syslog://aggregate-drain2.url.com?include-metrics-deprecated=true",
+					Type:  syslog.BINDING_TYPE_AGGREGATE,
+				},
+			))
+		})
+
+		It("only returns valid drain bindings for the drain urls", func() {
+			bs := []string{
+				"syslog://aggregate-drain1.url.com",
+				"B@D/aggregate-d\rain1.//l.cm",
+			}
+			fetcher := bindings.NewAggregateDrainFetcher(bs, nil)
+
+			b, err := fetcher.FetchBindings()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(b).To(ConsistOf(
+				syslog.Binding{
+					AppId: "",
+					Drain: "syslog://aggregate-drain1.url.com",
+					Type:  syslog.BINDING_TYPE_LOG,
+				},
+			))
+		})
+
+		It("handles empty drain bindings", func() {
+			bs := []string{""}
+			fetcher := bindings.NewAggregateDrainFetcher(bs, nil)
+
+			b, err := fetcher.FetchBindings()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(b)).To(Equal(0))
+		})
 	})
+	Context("cache fetcher exists", func() {
+		It("ignores fetcher if both are available", func() {
+			bs := []string{
+				"syslog://aggregate-drain1.url.com",
+				"syslog://aggregate-drain2.url.com?include-metrics-deprecated=true",
+			}
+			cacheFetcher := mockCacheFetcher{bindings: []binding.Binding{{Drains: []string{"syslog://drain.url.com"}}}}
+			fetcher := bindings.NewAggregateDrainFetcher(bs, &cacheFetcher)
 
-	It("only returns valid drain bindings for the drain urls", func() {
-		bs := []string{
-			"syslog://aggregate-drain1.url.com",
-			"B@D/aggregate-d\rain1.//l.cm",
-		}
-		fetcher := bindings.NewAggregateDrainFetcher(bs)
+			b, err := fetcher.FetchBindings()
+			Expect(err).ToNot(HaveOccurred())
 
-		b, err := fetcher.FetchBindings()
-		Expect(err).ToNot(HaveOccurred())
+			Expect(b).To(ConsistOf(
+				syslog.Binding{
+					AppId: "",
+					Drain: "syslog://aggregate-drain1.url.com",
+					Type:  syslog.BINDING_TYPE_LOG,
+				},
+				syslog.Binding{
+					AppId: "",
+					Drain: "syslog://aggregate-drain2.url.com?include-metrics-deprecated=true",
+					Type:  syslog.BINDING_TYPE_AGGREGATE,
+				},
+			))
+		})
+		It("returns results from cache if no drains", func() {
+			bs := []string{""}
+			cacheFetcher := mockCacheFetcher{bindings: []binding.Binding{{Drains: []string{
+				"syslog://aggregate-drain1.url.com",
+				"syslog://aggregate-drain2.url.com?include-metrics-deprecated=true",
+				"B@D/aggregate-d\rain1.//l.cm",
+			}}}}
+			fetcher := bindings.NewAggregateDrainFetcher(bs, &cacheFetcher)
 
-		Expect(b).To(ConsistOf(
-			syslog.Binding{
-				AppId: "",
-				Drain: "syslog://aggregate-drain1.url.com",
-				Type:  syslog.BINDING_TYPE_LOG,
-			},
-		))
-	})
+			b, err := fetcher.FetchBindings()
+			Expect(err).ToNot(HaveOccurred())
 
-	It("handles empty drain bindings", func() {
-		bs := []string{""}
-		fetcher := bindings.NewAggregateDrainFetcher(bs)
+			Expect(b).To(ConsistOf(
+				syslog.Binding{
+					AppId: "",
+					Drain: "syslog://aggregate-drain1.url.com",
+					Type:  syslog.BINDING_TYPE_LOG,
+				},
+				syslog.Binding{
+					AppId: "",
+					Drain: "syslog://aggregate-drain2.url.com?include-metrics-deprecated=true",
+					Type:  syslog.BINDING_TYPE_AGGREGATE,
+				},
+			))
+		})
+		It("returns error if fetching fails", func() {
+			bs := []string{""}
+			cacheFetcher := mockCacheFetcher{err: errors.New("error")}
+			fetcher := bindings.NewAggregateDrainFetcher(bs, &cacheFetcher)
 
-		b, err := fetcher.FetchBindings()
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(len(b)).To(Equal(0))
+			_, err := fetcher.FetchBindings()
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })
+
+type mockCacheFetcher struct {
+	bindings []binding.Binding
+	err      error
+}
+
+func (m *mockCacheFetcher) GetAggregate() ([]binding.Binding, error) {
+	return m.bindings, m.err
+}

--- a/src/pkg/plumbing/tls.go
+++ b/src/pkg/plumbing/tls.go
@@ -1,13 +1,14 @@
 package plumbing
 
 import (
-	"code.cloudfoundry.org/tlsconfig"
 	"crypto/tls"
-	"google.golang.org/grpc/credentials"
 	"log"
 	"net"
 	"net/http"
 	"time"
+
+	"code.cloudfoundry.org/tlsconfig"
+	"google.golang.org/grpc/credentials"
 )
 
 var defaultServerCipherSuites = []uint16{

--- a/src/pkg/scraper/config_provider.go
+++ b/src/pkg/scraper/config_provider.go
@@ -2,11 +2,12 @@ package scraper
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 type PromScraperConfig struct {
@@ -66,7 +67,7 @@ func (p *ConfigProvider) filesForGlobs() []string {
 }
 
 func (p *ConfigProvider) parseConfig(file string) (PromScraperConfig, error) {
-	yamlFile, err := ioutil.ReadFile(file)
+	yamlFile, err := os.ReadFile(file)
 	if err != nil {
 		return PromScraperConfig{}, fmt.Errorf("cannot read file: %s", err)
 	}

--- a/src/pkg/scraper/config_provider_test.go
+++ b/src/pkg/scraper/config_provider_test.go
@@ -1,12 +1,12 @@
 package scraper_test
 
 import (
-	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/scraper"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
+
+	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/scraper"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -118,7 +118,7 @@ labels:
 )
 
 func metricPortConfigDir() string {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func metricPortConfigDir() string {
 }
 
 func writeScrapeConfigFile(metricConfigDir, config, fileName string) {
-	f, err := ioutil.TempFile(metricConfigDir, fileName)
+	f, err := os.CreateTemp(metricConfigDir, fileName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/pkg/scraper/dns_ip_provider.go
+++ b/src/pkg/scraper/dns_ip_provider.go
@@ -32,7 +32,7 @@ func NewDNSScrapeTargetProvider(sourceID, dnsFile string, port int) TargetProvid
 			ip := r[0]
 
 			targets = append(targets, Target{
-				ID: sourceID,
+				ID:        sourceID,
 				MetricURL: fmt.Sprintf("https://%s:%d/metrics", ip, port),
 			})
 		}

--- a/src/pkg/scraper/dns_ip_provider_test.go
+++ b/src/pkg/scraper/dns_ip_provider_test.go
@@ -1,10 +1,11 @@
 package scraper_test
 
 import (
+	"os"
+
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/scraper"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
 )
 
 var _ = Describe("DnsIpProvider", func() {
@@ -26,7 +27,7 @@ var _ = Describe("DnsIpProvider", func() {
 })
 
 func writeScrapeConfig(config string) string {
-	f, err := ioutil.TempFile("", "records.json")
+	f, err := os.CreateTemp("", "records.json")
 	Expect(err).ToNot(HaveOccurred())
 
 	_, err = f.Write([]byte(config))

--- a/src/pkg/scraper/scraper.go
+++ b/src/pkg/scraper/scraper.go
@@ -3,7 +3,6 @@ package scraper
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -149,12 +148,12 @@ func (s *Scraper) scrape(target Target) (map[string]*io_prometheus_client.Metric
 	}
 
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, body)
 	}
 

--- a/src/pkg/scraper/scraper_test.go
+++ b/src/pkg/scraper/scraper_test.go
@@ -2,7 +2,7 @@ package scraper_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -51,7 +51,7 @@ var _ = Describe("Scraper", func() {
 	var addResponse = func(tc *testContext, statusCode int, body string) {
 		tc.metricGetter.resp <- &http.Response{
 			StatusCode: statusCode,
-			Body:       ioutil.NopCloser(strings.NewReader(body)),
+			Body:       io.NopCloser(strings.NewReader(body)),
 		}
 	}
 


### PR DESCRIPTION
- use syslog-agent defined urls if they exist, ignore binding cache
- should speed up deploys of foundations when changing aggregate drains
  * only requires updating the syslog-binding-cache to change aggregate drains rather then all vms on the system.
  * keeps aggregate drains synced between deployments