### PR TITLE
log on recovery

### DIFF
--- a/src/cmd/prom-scraper/app/prom_scraper.go
+++ b/src/cmd/prom-scraper/app/prom_scraper.go
@@ -114,12 +114,17 @@ func (p *PromScraper) startScraper(scrapeConfig scraper.PromScraperConfig, ingre
 		metrics.WithMetricLabels(map[string]string{"scrape_target_source_id": scrapeConfig.SourceID}),
 	)
 
+	hadError := false
 	for {
 		select {
 		case <-ticker:
 			if err := s.Scrape(); err != nil {
+				hadError=true
 				failedScrapesTotal.Add(1)
 				p.log.Printf("failed to scrape: %s", err)
+			} else if hadError {
+				hadError=false
+				p.log.Printf("%s has recovered", scrapeConfig.InstanceID)
 			}
 		case <-p.stop:
 			return

--- a/src/cmd/prom-scraper/app/prom_scraper_test.go
+++ b/src/cmd/prom-scraper/app/prom_scraper_test.go
@@ -1,6 +1,7 @@
 package app_test
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"net"
@@ -378,6 +379,34 @@ var _ = Describe("PromScraper", func() {
 				return metricClient.GetMetric("failed_scrapes_total", map[string]string{"scrape_target_source_id": "some-id"}).Value()
 			}).Should(BeNumerically(">=", 1))
 		})
+
+		It("logs on recovery", func() {
+			logBuffer := new(bytes.Buffer)
+			testLogger := log.New(logBuffer, "", log.LstdFlags)
+			promServer = newStubPromServer()
+
+			By("start scraper", func() {
+				spyConfigProvider.scrapeConfigs = []scraper.PromScraperConfig{
+					{
+						Port:       promServer.port,
+						SourceID:   "some-id",
+						InstanceID: "some-instance-id",
+						Path:       "metrics",
+					},
+				}
+
+				ps = app.NewPromScraper(cfg, spyConfigProvider.Configs, metricClient, testLogger)
+				go ps.Run()
+			})
+			By("simulate failure", func() {
+				promServer.statusCode=http.StatusGatewayTimeout
+				Eventually(logBuffer.String).Should(ContainSubstring("failed to scrape"))
+			})
+			By("simulate recovery", func() {
+				promServer.statusCode=http.StatusOK
+				Eventually(logBuffer.String).Should(ContainSubstring("has recovered"))
+			})
+		})
 	})
 })
 
@@ -390,6 +419,7 @@ func hasMetric(metricClient *metricsHelpers.SpyMetricsRegistry, name string, tag
 type stubPromServer struct {
 	resp string
 	port string
+	statusCode int
 
 	requestHeaders chan http.Header
 	requestPaths   chan string
@@ -406,6 +436,7 @@ func newStubPromServer() *stubPromServer {
 	addr := server.URL
 	tokens := strings.Split(addr, ":")
 	s.port = tokens[len(tokens)-1]
+	s.statusCode = http.StatusOK
 
 	return s
 }
@@ -433,6 +464,7 @@ func newStubHttpsPromServer(testLogger *log.Logger, scrapeCerts *testhelper.Test
 	addr := server.Listener.Addr().String()
 	tokens := strings.Split(addr, ":")
 	s.port = tokens[len(tokens)-1]
+	s.statusCode = http.StatusOK
 
 	return s
 }
@@ -440,6 +472,8 @@ func newStubHttpsPromServer(testLogger *log.Logger, scrapeCerts *testhelper.Test
 func (s *stubPromServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.requestHeaders <- req.Header
 	s.requestPaths <- req.URL.Path
+
+	w.WriteHeader(s.statusCode)
 	w.Write([]byte(s.resp))
 }
 


### PR DESCRIPTION
this change allows us to also see a log message when the scrape succeeds
after a failure occured.

only logs once per recovery