### PR TITLE
skip config files with invalid ports

### DIFF
--- a/src/pkg/scraper/config_provider.go
+++ b/src/pkg/scraper/config_provider.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -45,7 +46,12 @@ func (p *ConfigProvider) Configs() ([]PromScraperConfig, error) {
 		if err != nil {
 			return nil, err
 		}
-		targets = append(targets, scraperConfig)
+		portInt, err := strconv.Atoi(scraperConfig.Port)
+		if err != nil || portInt <= 0 || portInt > 65536 {
+			p.log.Println(fmt.Sprintf("Prom scraper config at %s does not have a valid port - skipping this config file\n", f))
+		} else {
+			targets = append(targets, scraperConfig)
+		}
 	}
 
 	return targets, nil

--- a/src/pkg/scraper/config_provider_test.go
+++ b/src/pkg/scraper/config_provider_test.go
@@ -1,6 +1,7 @@
 package scraper_test
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"os"
@@ -94,6 +95,50 @@ var _ = Describe("PromScraper", func() {
 			Expect(ps[0].ScrapeInterval).To(Equal(100 * time.Millisecond))
 		})
 	})
+
+	It("returns a error if port is not set", func() {
+		writeScrapeConfigFile(metricConfigDir, metricConfigEmpty, "prom_scraper_config.yml")
+
+		var buffer bytes.Buffer
+		assertableLogger := log.New(&buffer, "", log.LstdFlags)
+		ps, err := scraper.NewConfigProvider([]string{configGlobs}, defaultScrapeInterval, assertableLogger).Configs()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ps).To(HaveLen(0))
+		Expect(string(buffer.Bytes())).To(MatchRegexp("Prom scraper config at /tmp/[0-9]*/prom_scraper_config.yml[0-9]* does not have a valid port - skipping this config file"))
+	})
+
+	It("returns a error if port is less than 1", func() {
+		writeScrapeConfigFile(metricConfigDir, metricConfigPortTooSmall, "prom_scraper_config.yml")
+
+		var buffer bytes.Buffer
+		assertableLogger := log.New(&buffer, "", log.LstdFlags)
+		ps, err := scraper.NewConfigProvider([]string{configGlobs}, defaultScrapeInterval, assertableLogger).Configs()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ps).To(HaveLen(0))
+		Expect(string(buffer.Bytes())).To(MatchRegexp("Prom scraper config at /tmp/[0-9]*/prom_scraper_config.yml[0-9]* does not have a valid port - skipping this config file"))
+	})
+
+	It("returns a error if port is greater than 65536", func() {
+		writeScrapeConfigFile(metricConfigDir, metricConfigPortTooLarge, "prom_scraper_config.yml")
+
+		var buffer bytes.Buffer
+		assertableLogger := log.New(&buffer, "", log.LstdFlags)
+		ps, err := scraper.NewConfigProvider([]string{configGlobs}, defaultScrapeInterval, assertableLogger).Configs()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ps).To(HaveLen(0))
+		Expect(string(buffer.Bytes())).To(MatchRegexp("Prom scraper config at /tmp/[0-9]*/prom_scraper_config.yml[0-9]* does not have a valid port - skipping this config file"))
+	})
+
+	It("returns a error if port is not a number", func() {
+		writeScrapeConfigFile(metricConfigDir, metricConfigPortNotANumber, "prom_scraper_config.yml")
+
+		var buffer bytes.Buffer
+		assertableLogger := log.New(&buffer, "", log.LstdFlags)
+		ps, err := scraper.NewConfigProvider([]string{configGlobs}, defaultScrapeInterval, assertableLogger).Configs()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ps).To(HaveLen(0))
+		Expect(string(buffer.Bytes())).To(MatchRegexp("Prom scraper config at /tmp/[0-9]*/prom_scraper_config.yml[0-9]* does not have a valid port - skipping this config file"))
+	})
 })
 
 const (
@@ -101,6 +146,14 @@ const (
 port: 8080
 source_id: some-id
 instance_id: some-instance-id`
+
+	metricConfigEmpty        = `---`
+	metricConfigPortTooSmall = `---
+port: 0`
+	metricConfigPortTooLarge = `---
+port: 65537 `
+	metricConfigPortNotANumber = `---
+port: foo`
 
 	metricConfigWithAllFieldsSpecifiedTemplate = `---
 port: 8081


### PR DESCRIPTION
allows optionally configuring prom scraping for releases

Signed-off-by: Matthew Kocher <mkocher@vmware.com>