### PR TITLE
Update docs to reflect that prom_scraper_config.yml needs underscores…

### DIFF
--- a/docs/prom-scraper.md
+++ b/docs/prom-scraper.md
@@ -10,7 +10,7 @@ Prom Scraper can be used to scrape Prometheus Exposition style endpoints on loca
 
 ### Configuring scraping
 Add a config file matching one of the globs in the `config_globs` property in prom scraper.
-  - By default, prom scraper looks for a `prom-scraper-config.yml` file in each job's config directory
+  - By default, prom scraper looks for a `prom_scraper_config.yml` file in each job's config directory
   
 #### File contents
 ```yaml
@@ -23,7 +23,7 @@ headers: Optional - a map of headers to add to the scrape request
 labels: Optional - a map of labels that will be added to all metrics
 ```
 
-#### Example `prom-scraper-config.yml.erb`
+#### Example `prom_scraper_config.yml.erb`
 ```yaml
 port: 6061
 source_id: "my-job-name"


### PR DESCRIPTION
…, not hyphens

# Description

We hit a gotcha when configuring prom-scraper, and that was that prom-scraper looks for config files named `prom_scraper_config.yml`, not `prom-scraper-config.yml`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

