### PR TITLE
Remove noisy logging for invalid app drains

### DIFF
--- a/src/pkg/ingress/bindings/blacklist_ranges.go
+++ b/src/pkg/ingress/bindings/blacklist_ranges.go
@@ -2,10 +2,8 @@ package bindings
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"net"
-	"net/url"
 	"strings"
 )
 
@@ -83,6 +81,7 @@ func (i *BlacklistRanges) CheckBlacklist(ip net.IP) error {
 func (i *BlacklistRanges) ResolveAddr(host string) (net.IP, error) {
 	ipAddress := net.ParseIP(host)
 	if ipAddress == nil {
+		host = strings.Split(host, ":")[0]
 		ipAddr, err := net.ResolveIPAddr("ip", host)
 		if err != nil {
 			return nil, fmt.Errorf("unable to resolve DNS entry: %s", host)
@@ -91,19 +90,4 @@ func (i *BlacklistRanges) ResolveAddr(host string) (net.IP, error) {
 	}
 
 	return ipAddress, nil
-}
-
-func (i *BlacklistRanges) ParseHost(drainURL string) (string, string, error) {
-	testURL, err := url.Parse(drainURL)
-	if err != nil {
-		return "", "", err
-	}
-
-	if len(testURL.Host) == 0 {
-		return "", "", errors.New("invalid URL, detected no host")
-	}
-
-	host := strings.Split(testURL.Host, ":")[0]
-
-	return testURL.Scheme, host, nil
 }

--- a/src/pkg/ingress/bindings/blacklist_ranges_test.go
+++ b/src/pkg/ingress/bindings/blacklist_ranges_test.go
@@ -73,40 +73,19 @@ var _ = Describe("BlacklistRanges", func() {
 		})
 	})
 
-	Describe("ParseHost()", func() {
-		It("does not return an error on valid URL", func() {
-			ranges, _ := bindings.NewBlacklistRanges()
-
-			for _, testUrl := range validIPs {
-				_, host, err := ranges.ParseHost(testUrl)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(host).ToNot(Equal(""))
-			}
-		})
-
-		It("returns error on malformatted URL", func() {
-			ranges, _ := bindings.NewBlacklistRanges()
-
-			for _, testUrl := range malformattedURLs {
-				_, host, err := ranges.ParseHost(testUrl)
-				Expect(err).To(HaveOccurred())
-				Expect(host).To(Equal(""))
-			}
-		})
-
-		It("returns the scheme from a valid URL", func() {
-			ranges, _ := bindings.NewBlacklistRanges()
-			scheme, _, err := ranges.ParseHost("syslog://10.10.10.10")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(scheme).To(Equal("syslog"))
-		})
-	})
-
 	Describe("ResolveAddr()", func() {
 		It("does not return an error when able to resolve", func() {
 			ranges, _ := bindings.NewBlacklistRanges()
 
 			ip, err := ranges.ResolveAddr("localhost")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip.String()).To(Equal("127.0.0.1"))
+		})
+
+		It("can resolve addresses with port", func() {
+			ranges, _ := bindings.NewBlacklistRanges()
+
+			ip, err := ranges.ResolveAddr("localhost:8080")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ip.String()).To(Equal("127.0.0.1"))
 		})


### PR DESCRIPTION
- if logic for invalid app drains emitting logs exists, it should
   - exist in the binding cache, not every single syslog-agent
   - be less noisy
   - go to the app log stream rather then operator logs

- fixed certain drains to not be marked as invalid (aka, drains processed by other components)

Signed-off-by: Matthew Kocher <mkocher@vmware.com>

# Description

Please include a summary of the change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

