### PR TITLE
max message size changes

### DIFF
--- a/src/cmd/agent/app/app_v2.go
+++ b/src/cmd/agent/app/app_v2.go
@@ -137,6 +137,7 @@ func (a *AppV2) Start() {
 		rx,
 		grpc.Creds(a.serverCreds),
 		grpc.KeepaliveEnforcementPolicy(kp),
+		grpc.MaxRecvMsgSize(10*1024*1024),
 	)
 	ingressServer.Start()
 }

--- a/src/cmd/forwarder-agent/app/forwarder_agent.go
+++ b/src/cmd/forwarder-agent/app/forwarder_agent.go
@@ -122,6 +122,7 @@ func (s ForwarderAgent) Run() {
 		fmt.Sprintf("127.0.0.1:%d", s.grpc.Port),
 		rx,
 		grpc.Creds(serverCreds),
+		grpc.MaxRecvMsgSize(10*1024*1024),
 	)
 	srv.Start()
 }

--- a/src/cmd/syslog-agent/app/syslog_agent.go
+++ b/src/cmd/syslog-agent/app/syslog_agent.go
@@ -247,6 +247,7 @@ func (s *SyslogAgent) Run() {
 		fmt.Sprintf("127.0.0.1:%d", s.grpc.Port),
 		rx,
 		grpc.Creds(serverCreds),
+		grpc.MaxRecvMsgSize(10*1024*1024),
 	)
 	srv.Start()
 }

--- a/src/pkg/egress/syslog/tcp.go
+++ b/src/pkg/egress/syslog/tcp.go
@@ -77,13 +77,7 @@ func (w *TCPWriter) Write(env *loggregator_v2.Envelope) error {
 
 	for _, msg := range msgs {
 		conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
-		_, err = conn.Write([]byte(strconv.Itoa(len(msg)) + " "))
-		if err != nil {
-			_ = w.Close()
-			return err
-		}
-
-		_, err = conn.Write(msg)
+		_, err = conn.Write([]byte(strconv.Itoa(len(msg)) + " " + string(msg)))
 		if err != nil {
 			_ = w.Close()
 			return err


### PR DESCRIPTION
# Description
- make sure we can handle batches of max sized envelopes from diego
   max size is 61440

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests
we ran this against a actual environment
## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

