### PR TITLE
Feat: prom scraper log on recovery

### DIFF
--- a/src/cmd/prom-scraper/app/prom_scraper.go
+++ b/src/cmd/prom-scraper/app/prom_scraper.go
@@ -124,12 +124,17 @@ func (p *PromScraper) startScraper(scrapeConfig scraper.PromScraperConfig, ingre
 		metrics.WithMetricLabels(map[string]string{"scrape_target_source_id": scrapeConfig.SourceID}),
 	)
 
+	hadError := false
 	for {
 		select {
 		case <-ticker:
 			if err := s.Scrape(); err != nil {
+				hadError=true
 				failedScrapesTotal.Add(1)
 				p.log.Printf("failed to scrape: %s", err)
+			} else if hadError {
+				hadError=false
+				p.log.Printf("%s has recovered", scrapeConfig.InstanceID)
 			}
 		case <-p.stop:
 			return

--- a/src/cmd/prom-scraper/app/prom_scraper.go
+++ b/src/cmd/prom-scraper/app/prom_scraper.go
@@ -129,11 +129,11 @@ func (p *PromScraper) startScraper(scrapeConfig scraper.PromScraperConfig, ingre
 		select {
 		case <-ticker:
 			if err := s.Scrape(); err != nil {
-				hadError=true
+				hadError = true
 				failedScrapesTotal.Add(1)
 				p.log.Printf("failed to scrape: %s", err)
 			} else if hadError {
-				hadError=false
+				hadError = false
 				p.log.Printf("%s has recovered", scrapeConfig.InstanceID)
 			}
 		case <-p.stop:


### PR DESCRIPTION
# Description

Prom scraper logs a recovery message when a scrape succeeds after a failure occurs.

Supersedes #73.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

