### PR TITLE
Add option for custom certs to prom scraper

### DIFF
--- a/docs/prom-scraper.md
+++ b/docs/prom-scraper.md
@@ -23,6 +23,14 @@ path: Optional - the path to the metrics endpoint (defaults to "/metrics")
 headers: Optional - a map of headers to add to the scrape request
 labels: Optional - a map of labels that will be added to all metrics
 scrape_interval: Optional - how often to scrape the metrics endpoint
+
+# NOTE: if you would like to override the use of certificates
+# ensure that you include a blob that includes your cert and key files
+# in the prom scraper job's additional_volumes property so that
+# it will not be blocked from viewing these files by bpm.
+ca_path: Optional - path to ca to override the default scraping ca.
+client_key_path: Optional - path to a client key to provide to override default mutual tls client key
+client_cert_path: Optional - path to a client cert to provide to override default mutual tls client cert
 ```
 
 #### Example `prom_scraper_config.yml.erb`

--- a/jobs/prom_scraper/spec
+++ b/jobs/prom_scraper/spec
@@ -29,6 +29,8 @@ properties:
   config_globs:
     description: "Files matching the globs are expected to contain information to scrape a Prometheus metrics endpoint on localhost."
     default: [/var/vcap/jobs/*/config/prom_scraper_config.yml, /var/vcap/jobs/*/config/metric_port.yml]
+  additional_volumes:
+    description: "Files matching these globs will be added to the bpm.yml but will not be attempted to be scraped"
   skip_ssl_validation:
     description: "If true, Skips SSL Validation when scraping"
     default: false

--- a/jobs/prom_scraper/templates/bpm.yml.erb
+++ b/jobs/prom_scraper/templates/bpm.yml.erb
@@ -10,9 +10,14 @@
   certs_dir = "/var/vcap/jobs/prom_scraper/config/certs"
 
   config_volumes = Array.new
-  if_p('config_globs') { |config_globs|
-    config_volumes = config_globs.map { |glob|
-      { "path" => glob, "mount_only" => true }
+  if_p('config_globs') { |globs|
+    globs.each { |glob|
+      config_volumes.append({ "path" => glob, "mount_only" => true })
+    }
+  }
+  if_p('additional_volumes') { |globs|
+    globs.each { |glob|
+      config_volumes.append({ "path" => glob, "mount_only" => true })
     }
   }
 

--- a/src/pkg/scraper/config_provider.go
+++ b/src/pkg/scraper/config_provider.go
@@ -20,6 +20,9 @@ type PromScraperConfig struct {
 	Path           string            `yaml:"path"`
 	Headers        map[string]string `yaml:"headers"`
 	Labels         map[string]string `yaml:"labels"`
+	CaPath         string            `yaml:"ca_path"`
+	ClientKeyPath  string            `yaml:"client_key_path"`
+	ClientCertPath string            `yaml:"client_cert_path"`
 	ScrapeInterval time.Duration     `yaml:"scrape_interval"`
 }
 


### PR DESCRIPTION
- services and externally deployed offerings might wish to expose metrics endpoints with certs that are
    more internet friendly then the "metrics only prom scraper certs" or fit in with their own cert ecosystem
    this allows overriding the default loggregator certs and ca used when prom scraping a job.

# Description

Please include a summary of the change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

