### PR TITLE
Futureproofing async ginkgo testing

### DIFF
--- a/src/pkg/ingress/v1/network_reader_test.go
+++ b/src/pkg/ingress/v1/network_reader_test.go
@@ -36,7 +36,7 @@ var _ = Describe("NetworkReader", func() {
 	)
 
 	BeforeEach(func() {
-		port = randomPort() + GinkgoParallelNode()
+		port = randomPort() + GinkgoParallelProcess()
 		address = net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
 		writer = MockByteArrayWriter{}
 		metricClient = metricsHelpers.NewMetricsRegistry()

--- a/src/pkg/timeoutwaitgroup/timeout_wait_group_test.go
+++ b/src/pkg/timeoutwaitgroup/timeout_wait_group_test.go
@@ -9,41 +9,59 @@ import (
 )
 
 var _ = Describe("TimeoutWaitGroup", func() {
-	It("returns immediately if there is nothing to wait on", func(done Done) {
-		defer close(done)
+	It("returns immediately if there is nothing to wait on", func() {
+		done := make(chan interface{})
 
-		waiter := timeoutwaitgroup.New(time.Minute)
-
-		startTime := time.Now()
-		waiter.Wait()
-
-		Expect(time.Now().Sub(startTime)).To(BeNumerically("<", 100*time.Millisecond))
-	}, 1)
-
-	It("blocks for up to the timeout if there is something to wait on", func(done Done) {
-		defer close(done)
-
-		waiter := timeoutwaitgroup.New(50 * time.Millisecond)
-
-		waiter.Add(1)
-
-		startTime := time.Now()
-		waiter.Wait()
-		Expect(time.Now().Sub(startTime)).To(BeNumerically(">", 50*time.Millisecond))
-	}, 1)
-
-	It("returns before the timeout if everything finishes", func(done Done) {
-		defer close(done)
-
-		waiter := timeoutwaitgroup.New(time.Minute)
-		waiter.Add(1)
-
-		startTime := time.Now()
 		go func() {
-			time.Sleep(20 * time.Millisecond)
-			waiter.Done()
+			defer GinkgoRecover()
+			defer close(done)
+
+			waiter := timeoutwaitgroup.New(time.Minute)
+
+			startTime := time.Now()
+			waiter.Wait()
+
+			Expect(time.Since(startTime)).To(BeNumerically("<", 100*time.Millisecond))
 		}()
-		waiter.Wait()
-		Expect(time.Now().Sub(startTime)).To(BeNumerically("<", 100*time.Millisecond))
-	}, 1)
+		Eventually(done, 1).Should(BeClosed())
+	})
+
+	It("blocks for up to the timeout if there is something to wait on", func() {
+		done := make(chan interface{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+
+			waiter := timeoutwaitgroup.New(50 * time.Millisecond)
+
+			waiter.Add(1)
+
+			startTime := time.Now()
+			waiter.Wait()
+			Expect(time.Since(startTime)).To(BeNumerically(">", 50*time.Millisecond))
+		}()
+		Eventually(done, 1).Should(BeClosed())
+	})
+
+	It("returns before the timeout if everything finishes", func() {
+		done := make(chan interface{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+
+			waiter := timeoutwaitgroup.New(time.Minute)
+			waiter.Add(1)
+
+			startTime := time.Now()
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				waiter.Done()
+			}()
+			waiter.Wait()
+			Expect(time.Since(startTime)).To(BeNumerically("<", 100*time.Millisecond))
+		}()
+		Eventually(done, 1).Should(BeClosed())
+	})
 })


### PR DESCRIPTION
# Description

Ginkgo 2.0 is GA. Some of the tests are raising warnings about new features, improvements, and a small handful of breaking changes. This pull request addresses the following warnings:
- GinkgoParallelNode is deprecated and will be removed in Ginkgo V2.  Please use GinkgoParallelProcess instead. Learn more at: https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md#renamed-ginkgoparallelnode
- You are passing a Done channel to a test node to test asynchronous behavior.  This is deprecated in Ginkgo V2.  Your test will run synchronously and the timeout will be ignored. Learn more at: https://github.com/onsi/ginkgo/blob/ver2/docs/MIGRATING_TO_V2.md#removed-async-testing
- Using `time.Since(startTime)` instead of `time.Now().Sub(startTime)`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
