### PR TITLE
Add drain scope and url tags to syslog egress metrics

### DIFF
--- a/src/cmd/syslog-agent/app/syslog_agent_test.go
+++ b/src/cmd/syslog-agent/app/syslog_agent_test.go
@@ -129,7 +129,7 @@ var _ = Describe("SyslogAgent", func() {
 			Eventually(hasMetric(mc, "ingress", map[string]string{"scope": "all_drains"})).Should(BeTrue())
 
 			Eventually(hasMetric(mc, "dropped", map[string]string{"direction": "egress"})).Should(BeTrue())
-			Eventually(hasMetric(mc, "egress", nil)).Should(BeTrue())
+			Eventually(hasMetric(mc, "egress", map[string]string{"direction": "egress", "drain_scope": "aggregate", "drain_url": bindingCache.aggregate[0].Drains[0]})).Should(BeTrue())
 		})
 
 		It("does not have debug metrics by default", func() {

--- a/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
+++ b/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
@@ -242,15 +242,9 @@ var _ = Describe("SyslogBindingCache", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(results).To(HaveLen(2))
-		Expect(results[0].AppID).To(Equal("app-id-1"))
-		Expect(results[0].Drains[0]).To(Equal("syslog://drain-a"))
-		Expect(results[0].Drains[1]).To(Equal("syslog://drain-b"))
-		Expect(results[0].Hostname).To(Equal("org.space.app-name-1"))
-
-		Expect(results[1].AppID).To(Equal("app-id-2"))
-		Expect(results[1].Drains[0]).To(Equal("syslog://drain-c"))
-		Expect(results[1].Drains[1]).To(Equal("syslog://drain-d"))
-		Expect(results[1].Hostname).To(Equal("org.space.app-name-2"))
+		result1 := binding.LegacyBinding{AppID: "app-id-1", Drains: []string{"syslog://drain-a", "syslog://drain-b"}, Hostname: "org.space.app-name-1", V2Available: true}
+		result2 := binding.LegacyBinding{AppID: "app-id-2", Drains: []string{"syslog://drain-c", "syslog://drain-d"}, Hostname: "org.space.app-name-2", V2Available: true}
+		Expect(results).Should(ConsistOf(result1, result2))
 	})
 })
 

--- a/src/cmd/udp-forwarder/app/app_suite_test.go
+++ b/src/cmd/udp-forwarder/app/app_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestApp(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "UDP Forwwarder App Suite")
+	RunSpecs(t, "UDP Forwarder App Suite")
 }

--- a/src/pkg/egress/syslog/writer_factory.go
+++ b/src/pkg/egress/syslog/writer_factory.go
@@ -57,7 +57,6 @@ func NewWriterFactoryErrorf(kind WriterKind, bindingURL *url.URL, format string,
 type WriterFactory struct {
 	internalTlsConfig *tls.Config
 	externalTlsConfig *tls.Config
-	egressMetric      metrics.Counter
 	netConf           NetworkTimeoutConfig
 	m                 metricClient
 }
@@ -105,7 +104,7 @@ func (f WriterFactory) NewWriter(
 		drainScope = "aggregate"
 	}
 
-	f.egressMetric = f.m.NewCounter(
+	egressMetric := f.m.NewCounter(
 		"egress",
 		"Total number of envelopes successfully egressed.",
 		metrics.WithMetricLabels(map[string]string{
@@ -122,14 +121,14 @@ func (f WriterFactory) NewWriter(
 			urlBinding,
 			f.netConf,
 			tlsClonedConfig,
-			f.egressMetric,
+			egressMetric,
 			converter,
 		)
 	case "syslog":
 		w = NewTCPWriter(
 			urlBinding,
 			f.netConf,
-			f.egressMetric,
+			egressMetric,
 			converter,
 		)
 	case "syslog-tls":
@@ -137,7 +136,7 @@ func (f WriterFactory) NewWriter(
 			urlBinding,
 			f.netConf,
 			tlsClonedConfig,
-			f.egressMetric,
+			egressMetric,
 			converter,
 		)
 	}

--- a/src/pkg/egress/syslog/writer_factory_test.go
+++ b/src/pkg/egress/syslog/writer_factory_test.go
@@ -17,16 +17,6 @@ var _ = Describe("EgressFactory", func() {
 		sm *metricsHelpers.SpyMetricsRegistry
 	)
 
-	type egressMetric struct {
-		name string
-		tags map[string]string
-	}
-
-	type testCase struct {
-		URLBinding syslog.URLBinding
-		metric     egressMetric
-	}
-
 	BeforeEach(func() {
 		sm = metricsHelpers.NewMetricsRegistry()
 		f = syslog.NewWriterFactory(&tls.Config{}, &tls.Config{}, syslog.NetworkTimeoutConfig{}, sm) //nolint:gosec


### PR DESCRIPTION
# Description
Add drain scope and url tags to egress metric in order to enable better tracking of syslog messages per drain. As perviously discussed on [slack](https://cloudfoundry.slack.com/archives/CUW93AF3M/p1656599906962669?thread_ts=1654252617.471169&cid=CUW93AF3M) , we added tags to the syslog egress drain metric.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

