### PR TITLE
CI: fix go workflow target for version branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,10 +3,10 @@ name: Go
 on:
   push:
     branches:
-    - main
+    - v6.x
   pull_request:
     branches:
-    - main
+    - v6.x
 
 jobs:
   test:


### PR DESCRIPTION
# Description

Make go workflow run properly against PRs to `v6.x`.

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
