### PR TITLE
CI: add branch-specific labels to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -12,10 +11,12 @@ updates:
     directory: "/src"
     schedule:
       interval: "daily"
-
-  # Maintain dependencies for Go Modules
   - package-ecosystem: "gomod"
     directory: "/src"
     target-branch: "v6.x"
     schedule:
       interval: "daily"
+    labels:
+    - "v6.x"
+    - "go"
+    - "dependencies"


### PR DESCRIPTION
# Description

Makes it easier to distinguish between dependabot PRs for different target branches.

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
