### PR TITLE
Fix: anonymize URL in syslog drain logs and metrics

### DIFF
--- a/src/pkg/egress/syslog/writer_factory.go
+++ b/src/pkg/egress/syslog/writer_factory.go
@@ -52,83 +52,80 @@ func NewWriterFactory(internalTlsConfig *tls.Config, externalTlsConfig *tls.Conf
 	}
 }
 
-func (f WriterFactory) NewWriter(
-	urlBinding *URLBinding,
-) (egress.WriteCloser, error) {
-	var o []ConverterOption
-	if urlBinding.OmitMetadata {
-		o = append(o, WithoutSyslogMetadata())
+func (f WriterFactory) NewWriter(ub *URLBinding) (egress.WriteCloser, error) {
+	tlsCfg := f.externalTlsConfig.Clone()
+	if ub.InternalTls {
+		tlsCfg = f.internalTlsConfig.Clone()
 	}
-	tlsConfig := f.externalTlsConfig
-	if urlBinding.InternalTls {
-		tlsConfig = f.internalTlsConfig
-	}
-	converter := NewConverter(o...)
-	tlsClonedConfig := tlsConfig.Clone()
-	if len(urlBinding.Certificate) > 0 && len(urlBinding.PrivateKey) > 0 {
-		cert, err := tls.X509KeyPair(urlBinding.Certificate, urlBinding.PrivateKey)
+	if len(ub.Certificate) > 0 && len(ub.PrivateKey) > 0 {
+		cert, err := tls.X509KeyPair(ub.Certificate, ub.PrivateKey)
 		if err != nil {
-			err = NewWriterFactoryErrorf(urlBinding.URL, "failed to load certificate: %s", err.Error())
+			err = NewWriterFactoryErrorf(ub.URL, "failed to load certificate: %s", err.Error())
 			return nil, err
 		}
-		tlsClonedConfig.Certificates = []tls.Certificate{cert}
+		tlsCfg.Certificates = []tls.Certificate{cert}
 	}
-	if len(urlBinding.CA) > 0 {
-		ok := tlsClonedConfig.RootCAs.AppendCertsFromPEM(urlBinding.CA)
+	if len(ub.CA) > 0 {
+		ok := tlsCfg.RootCAs.AppendCertsFromPEM(ub.CA)
 		if !ok {
-			err := NewWriterFactoryErrorf(urlBinding.URL, "failed to load root CA")
+			err := NewWriterFactoryErrorf(ub.URL, "failed to load root CA")
 			return nil, err
 		}
 	}
 
 	drainScope := "app"
-	if urlBinding.AppID == "" {
+	if ub.AppID == "" {
 		drainScope = "aggregate"
 	}
-
 	egressMetric := f.m.NewCounter(
 		"egress",
 		"Total number of envelopes successfully egressed.",
 		metrics.WithMetricLabels(map[string]string{
 			"direction":   "egress",
 			"drain_scope": drainScope,
-			"drain_url":   urlBinding.URL.String(),
+			"drain_url":   ub.URL.String(),
 		}),
 	)
 
+	var o []ConverterOption
+	if ub.OmitMetadata {
+		o = append(o, WithoutSyslogMetadata())
+	}
+	converter := NewConverter(o...)
+
 	var w egress.WriteCloser
-	switch urlBinding.URL.Scheme {
+	switch ub.URL.Scheme {
 	case "https":
 		w = NewHTTPSWriter(
-			urlBinding,
+			ub,
 			f.netConf,
-			tlsClonedConfig,
+			tlsCfg,
 			egressMetric,
 			converter,
 		)
 	case "syslog":
 		w = NewTCPWriter(
-			urlBinding,
+			ub,
 			f.netConf,
 			egressMetric,
 			converter,
 		)
 	case "syslog-tls":
 		w = NewTLSWriter(
-			urlBinding,
+			ub,
 			f.netConf,
-			tlsClonedConfig,
+			tlsCfg,
 			egressMetric,
 			converter,
 		)
 	}
 
 	if w == nil {
-		return nil, NewWriterFactoryErrorf(urlBinding.URL, "unsupported protocol: %q", urlBinding.URL.Scheme)
+		return nil, NewWriterFactoryErrorf(ub.URL, "unsupported protocol: %q", ub.URL.Scheme)
 	}
 
 	return NewRetryWriter(
-		urlBinding,
+		ub,
 		ExponentialDuration,
 		maxRetries,
 		w,

--- a/src/pkg/egress/syslog/writer_factory.go
+++ b/src/pkg/egress/syslog/writer_factory.go
@@ -77,13 +77,16 @@ func (f WriterFactory) NewWriter(ub *URLBinding) (egress.WriteCloser, error) {
 	if ub.AppID == "" {
 		drainScope = "aggregate"
 	}
+	anonymousURL := *ub.URL
+	anonymousURL.User = nil
+	anonymousURL.RawQuery = ""
 	egressMetric := f.m.NewCounter(
 		"egress",
 		"Total number of envelopes successfully egressed.",
 		metrics.WithMetricLabels(map[string]string{
 			"direction":   "egress",
 			"drain_scope": drainScope,
-			"drain_url":   ub.URL.String(),
+			"drain_url":   anonymousURL.String(),
 		}),
 	)
 

--- a/src/pkg/egress/syslog/writer_factory.go
+++ b/src/pkg/egress/syslog/writer_factory.go
@@ -13,15 +13,6 @@ type metricClient interface {
 	NewCounter(name, helpText string, o ...metrics.MetricOption) metrics.Counter
 }
 
-type WriterKind int
-
-const (
-	Https WriterKind = iota
-	Syslog
-	SyslogTLS
-	Unsupported
-)
-
 type WriterFactoryError struct {
 	Message string
 	URL     *url.URL

--- a/src/pkg/egress/syslog/writer_factory_test.go
+++ b/src/pkg/egress/syslog/writer_factory_test.go
@@ -78,22 +78,6 @@ var _ = Describe("EgressFactory", func() {
 			Expect(ok).To(BeTrue())
 		})
 
-		Context("when the certificate or private key is invalid", func() {
-			It("returns an error", func() {
-				url, err := url.Parse("syslog-tls://syslog.example.com")
-				Expect(err).ToNot(HaveOccurred())
-				urlBinding := &syslog.URLBinding{
-					URL:         url,
-					Certificate: []byte("invalid-certificate"),
-					PrivateKey:  []byte("invalid-private-key"),
-				}
-
-				_, err = f.NewWriter(urlBinding)
-				Expect(err).To(MatchError(MatchRegexp(
-					`failed to load certificate: tls:.*, binding: "syslog-tls://syslog.example.com"`)))
-			})
-		})
-
 		Context("when the private key is not passed", func() {
 			It("the certificate is ignored", func() {
 				url, err := url.Parse("syslog-tls://syslog.example.com")
@@ -121,61 +105,62 @@ var _ = Describe("EgressFactory", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
-
-		Context("when the certificate authority is invalid", func() {
-			It("returns an error", func() {
-				url, err := url.Parse("syslog-tls://syslog.example.com")
-				Expect(err).ToNot(HaveOccurred())
-				urlBinding := &syslog.URLBinding{
-					URL: url,
-					CA:  []byte("invalid-ca-certificate"),
-				}
-
-				_, err = f.NewWriter(urlBinding)
-				Expect(err).To(MatchError(MatchRegexp(
-					`failed to load root ca, binding: "syslog-tls://syslog.example.com"`)))
-			})
-		})
 	})
 
-	Context("when the binding has an invalid scheme", func() {
-		It("returns an error", func() {
-			url, err := url.Parse("invalid://syslog.example.com")
+	DescribeTable("Errors",
+		func(u string, certFail bool, caFail bool, expectedErr string) {
+			url, err := url.Parse(u)
 			Expect(err).ToNot(HaveOccurred())
 			urlBinding := &syslog.URLBinding{
 				URL: url,
 			}
 
+			if certFail {
+				urlBinding.Certificate = []byte("invalid-cert")
+				urlBinding.PrivateKey = []byte("invalid-key")
+			}
+
+			if caFail {
+				urlBinding.CA = []byte("invalid-ca")
+			}
+
 			_, err = f.NewWriter(urlBinding)
-			Expect(err).To(MatchError(`unsupported protocol: "invalid", binding: "invalid://syslog.example.com"`))
-		})
-	})
 
-	DescribeTable("metrics", func(u string, aggregate bool) {
-		url, err := url.Parse(u)
-		Expect(err).ToNot(HaveOccurred())
-		appID := "app-id"
-		tags := map[string]string{"direction": "egress", "drain_scope": "app", "drain_url": u}
-		if aggregate {
-			appID = ""
-			tags["drain_scope"] = "aggregate"
-		}
-		urlBinding := &syslog.URLBinding{
-			URL:   url,
-			AppID: appID,
-		}
+			Expect(err).To(MatchError(expectedErr))
+		},
+		Entry("When the scheme is invalid", "invalid://syslog.example.com", false, false, `"invalid://syslog.example.com": unsupported protocol: "invalid"`),
+		Entry("When the scheme is https and the cert/key pair is invalid", "https://username:password@syslog.example.com", true, false, `"https://syslog.example.com": failed to load certificate: tls: failed to find any PEM data in certificate input`),
+		Entry("When the scheme is https and the CA is invalid", "https://username:password@syslog.example.com", false, true, `"https://syslog.example.com": failed to load root CA`),
+		Entry("When the scheme is syslog-tls and the cert/key pair is invalid", "syslog-tls://username:password@syslog.example.com", true, false, `"syslog-tls://syslog.example.com": failed to load certificate: tls: failed to find any PEM data in certificate input`),
+		Entry("When the scheme is syslog-tls and the CA is invalid", "syslog-tls://username:password@syslog.example.com", false, true, `"syslog-tls://syslog.example.com": failed to load root CA`),
+	)
 
-		_, err = f.NewWriter(urlBinding)
-		Expect(err).ToNot(HaveOccurred())
+	DescribeTable("Metrics",
+		func(u string, aggregate bool) {
+			url, err := url.Parse(u)
+			Expect(err).ToNot(HaveOccurred())
+			appID := "app-id"
+			tags := map[string]string{"direction": "egress", "drain_scope": "app", "drain_url": u}
+			if aggregate {
+				appID = ""
+				tags["drain_scope"] = "aggregate"
+			}
+			urlBinding := &syslog.URLBinding{
+				URL:   url,
+				AppID: appID,
+			}
 
-		metric := sm.GetMetric("egress", tags)
-		Expect(metric).ToNot(BeNil())
-	},
-		Entry("https aggregate drain", "https://syslog.example.com", true),
-		Entry("https app drain", "https://syslog.example.com", false),
-		Entry("syslog aggregate drain", "syslog://syslog.example.com", true),
-		Entry("syslog app drain", "syslog://syslog.example.com", false),
-		Entry("syslog-tls aggregate drain", "syslog-tls://syslog.example.com", true),
-		Entry("syslog-tls app drain", "syslog-tls://syslog.example.com", false),
+			_, err = f.NewWriter(urlBinding)
+			Expect(err).ToNot(HaveOccurred())
+
+			metric := sm.GetMetric("egress", tags)
+			Expect(metric).ToNot(BeNil())
+		},
+		Entry("For https aggregate drain", "https://syslog.example.com", true),
+		Entry("For https app drain", "https://syslog.example.com", false),
+		Entry("For syslog aggregate drain", "syslog://syslog.example.com", true),
+		Entry("For syslog app drain", "syslog://syslog.example.com", false),
+		Entry("For syslog-tls aggregate drain", "syslog-tls://syslog.example.com", true),
+		Entry("For syslog-tls app drain", "syslog-tls://syslog.example.com", false),
 	)
 })


### PR DESCRIPTION
# Description

Anonymizes URL emitted in syslog drain logs and syslog drain metrics.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
