### PR TITLE
Add app-id and drain url in the error message

### DIFF
--- a/src/pkg/egress/syslog/syslog_connector.go
+++ b/src/pkg/egress/syslog/syslog_connector.go
@@ -138,7 +138,7 @@ func (w *SyslogConnector) Connect(ctx context.Context, b Binding) (egress.Writer
 		w.droppedMetric.Add(float64(missed))
 		drainDroppedMetric.Add(float64(missed))
 
-		w.emitLoggregatorErrorLog(b.AppId, fmt.Sprintf("%d messages lost in user provided syslog drain", missed))
+		w.emitLoggregatorErrorLog(b.AppId, fmt.Sprintf("%d messages lost for application %s in user provided syslog drain with url %s", missed, b.AppId, anonymousUrl.String()))
 		w.emitStandardOutErrorLog(b.AppId, urlBinding.Scheme(), anonymousUrl.String(), missed)
 	}), w.wg)
 

--- a/src/pkg/egress/syslog/syslog_connector_test.go
+++ b/src/pkg/egress/syslog/syslog_connector_test.go
@@ -201,7 +201,7 @@ var _ = Describe("SyslogConnector", func() {
 				}
 			}(writer)
 
-			Eventually(logClient.message).Should(ContainElement(MatchRegexp("\\d messages lost in user provided syslog drain")))
+			Eventually(logClient.message).Should(ContainElement(MatchRegexp("\\d messages lost for application (.*) in user provided syslog drain with url")))
 			Eventually(logClient.appID).Should(ContainElement("app-id"))
 
 			Eventually(logClient.sourceType).Should(HaveLen(2))
@@ -239,7 +239,7 @@ var _ = Describe("SyslogConnector", func() {
 				}
 			}(writer)
 
-			Consistently(logClient.message).ShouldNot(ContainElement(MatchRegexp("\\d messages lost in user provided syslog drain")))
+			Consistently(logClient.message).ShouldNot(ContainElement(MatchRegexp("\\d messages lost for application (.*) in user provided syslog drain with url")))
 		})
 
 		It("does not panic on unknown dropped metrics", func() {


### PR DESCRIPTION
As discussed in #203 we've seen when an app has multiple syslog drains or one syslog drain was bound to multiple apps in was hard to tell which syslog drain for which app has log drops. We've adjusted the error message which is injected to the applications log, so that this becomes clear.
Now the error messages looks as following:
```
 2023-01-26T17:08:28.31+0000 [LGR/LGR] ERR 10000 messages lost for application <app-guid> in user provided syslog drain with url <anonymized-syslog-drain-url>
```
We've adjusted the unit test and did integration test, deployed the new version of the syslog-agent and checked the app logs for an application which produces many logs/s. We've also tested with a syslog url like `https://user:pass@example.com?p1=v1` and in the logs we only saw the "base url", `https://example.com` from the mentioned example. The anonymization that @ctlong implement works properly as well :tada: 

Fixes #203 

# Description

Please include a summary of the change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
