### PR TITLE
Remove the direction label as it is redundant

### DIFF
--- a/src/pkg/egress/syslog/writer_factory.go
+++ b/src/pkg/egress/syslog/writer_factory.go
@@ -84,7 +84,6 @@ func (f WriterFactory) NewWriter(ub *URLBinding) (egress.WriteCloser, error) {
 		"egress",
 		"Total number of envelopes successfully egressed.",
 		metrics.WithMetricLabels(map[string]string{
-			"direction":   "egress",
 			"drain_scope": drainScope,
 			"drain_url":   anonymousURL.String(),
 		}),

--- a/src/pkg/egress/syslog/writer_factory_test.go
+++ b/src/pkg/egress/syslog/writer_factory_test.go
@@ -140,7 +140,7 @@ var _ = Describe("EgressFactory", func() {
 			url, err := url.Parse(u)
 			Expect(err).ToNot(HaveOccurred())
 			appID := "app-id"
-			tags := map[string]string{"direction": "egress", "drain_scope": "app", "drain_url": u}
+			tags := map[string]string{"drain_scope": "app", "drain_url": u}
 			if aggregate {
 				appID = ""
 				tags["drain_scope"] = "aggregate"


### PR DESCRIPTION
The `direction` label (Syslog tag) was added together with the `drain_scope` and `drain_url` labels in #123. The `direction` was hardcoded to have value `egress` which is the same as the name of the metric which makes this label redundant.

# Description

Please include a summary of the change.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
