### PR TITLE
Create trivial go routine for negative scrape interval.

### DIFF
--- a/src/cmd/prom-scraper/app/prom_scraper_test.go
+++ b/src/cmd/prom-scraper/app/prom_scraper_test.go
@@ -162,7 +162,7 @@ var _ = Describe("PromScraper", func() {
 					Port:           promServer.port,
 					SourceID:       "some-id",
 					InstanceID:     "some-instance-id",
-					ScrapeInterval: -1,
+					ScrapeInterval: -1*time.Second,
 				},
 			}
 


### PR DESCRIPTION
Resolves #233 

# Description

Creates a trivial go routine that simply waits for stop when the scrape interval is negative. This prevents prom scraper from exiting immediately when only negative scrape intervals are configured.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing performed?

- [X] Unit tests

