### PR TITLE
CI: fix Go / Lint workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,5 +40,5 @@ jobs:
           go-version-file: "src/go.mod"
       - uses: golangci/golangci-lint-action@v3.4.0
         with:
-          args: --config .golangci.yml
+          args: --config .golangci.yml --timeout 5m
           working-directory: src


### PR DESCRIPTION
Increases timeout for `golangci-lint run` from 1m (default) to 5m.