### PR TITLE
Make keepalives for api polling configurable

### DIFF
--- a/jobs/loggr-syslog-binding-cache/spec
+++ b/jobs/loggr-syslog-binding-cache/spec
@@ -108,6 +108,10 @@ properties:
       The batch size the syslog will request the Cloud Controller for
       bindings.
     default: 1000
+  api.disable_keep_alives:
+    description: |
+      Configures if the polling connection to API is reused or not.
+    default: false
 
   metrics.port:
     description: "Port the agent uses to serve metrics and debug information"

--- a/jobs/loggr-syslog-binding-cache/spec
+++ b/jobs/loggr-syslog-binding-cache/spec
@@ -111,7 +111,7 @@ properties:
   api.disable_keep_alives:
     description: |
       Configures if the polling connection to API is reused or not.
-    default: false
+    default: true
 
   metrics.port:
     description: "Port the agent uses to serve metrics and debug information"

--- a/jobs/loggr-syslog-binding-cache/templates/bpm.yml.erb
+++ b/jobs/loggr-syslog-binding-cache/templates/bpm.yml.erb
@@ -15,6 +15,7 @@
       "API_URL" => "https://#{api_url}:9023",
       "API_POLLING_INTERVAL" => "#{p("api.polling_interval")}",
       "API_BATCH_SIZE" => "#{p("api.batch_size")}",
+      "API_DISABLE_KEEP_ALIVES" => "#{p("api.disable_keep_alives")}",
       "AGGREGATE_DRAINS_FILE" => "/var/vcap/jobs/loggr-syslog-binding-cache/config/aggregate_drains.yml",
 
       "CACHE_CA_FILE_PATH" => "#{certs_dir}/loggregator_ca.crt",

--- a/src/cmd/syslog-agent/app/syslog_agent.go
+++ b/src/cmd/syslog-agent/app/syslog_agent.go
@@ -102,6 +102,7 @@ func NewSyslogAgent(
 			cfg.Cache.KeyFile,
 			cfg.Cache.CAFile,
 			cfg.Cache.CommonName,
+			false,
 		)
 
 		cacheClient = cache.NewClient(cfg.Cache.URL, tlsClient)

--- a/src/cmd/syslog-binding-cache/app/config.go
+++ b/src/cmd/syslog-binding-cache/app/config.go
@@ -11,16 +11,17 @@ import (
 
 // Config holds the configuration for the syslog binding cache
 type Config struct {
-	UseRFC3339          bool          `env:"USE_RFC3339"`
-	APIURL              string        `env:"API_URL,              required, report"`
-	APICAFile           string        `env:"API_CA_FILE_PATH,     required, report"`
-	APICertFile         string        `env:"API_CERT_FILE_PATH,   required, report"`
-	APIKeyFile          string        `env:"API_KEY_FILE_PATH,    required, report"`
-	APICommonName       string        `env:"API_COMMON_NAME,      required, report"`
-	APIPollingInterval  time.Duration `env:"API_POLLING_INTERVAL, report"`
-	APIBatchSize        int           `env:"API_BATCH_SIZE, report"`
-	CipherSuites        []string      `env:"CIPHER_SUITES, report"`
-	AggregateDrainsFile string        `env:"AGGREGATE_DRAINS_FILE, report"`
+	UseRFC3339           bool          `env:"USE_RFC3339"`
+	APIURL               string        `env:"API_URL,              required, report"`
+	APICAFile            string        `env:"API_CA_FILE_PATH,     required, report"`
+	APICertFile          string        `env:"API_CERT_FILE_PATH,   required, report"`
+	APIKeyFile           string        `env:"API_KEY_FILE_PATH,    required, report"`
+	APICommonName        string        `env:"API_COMMON_NAME,      required, report"`
+	APIPollingInterval   time.Duration `env:"API_POLLING_INTERVAL, report"`
+	APIBatchSize         int           `env:"API_BATCH_SIZE, report"`
+	APIDisableKeepAlives bool          `env:"API_DISABLE_KEEP_ALIVES, report"`
+	CipherSuites         []string      `env:"CIPHER_SUITES, report"`
+	AggregateDrainsFile  string        `env:"AGGREGATE_DRAINS_FILE, report"`
 
 	CacheCAFile     string `env:"CACHE_CA_FILE_PATH,     required, report"`
 	CacheCertFile   string `env:"CACHE_CERT_FILE_PATH,   required, report"`

--- a/src/cmd/syslog-binding-cache/app/syslog_binding_cache.go
+++ b/src/cmd/syslog-binding-cache/app/syslog_binding_cache.go
@@ -84,6 +84,7 @@ func (sbc *SyslogBindingCache) apiClient() api.Client {
 		sbc.config.APIKeyFile,
 		sbc.config.APICAFile,
 		sbc.config.APICommonName,
+		sbc.config.APIDisableKeepAlives,
 	)
 
 	return api.Client{

--- a/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
+++ b/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
@@ -137,6 +137,7 @@ var _ = Describe("App", func() {
 			sbcCerts.Key(sbcCN),
 			sbcCerts.CA(),
 			sbcCN,
+			false,
 		)
 	})
 

--- a/src/pkg/plumbing/tls.go
+++ b/src/pkg/plumbing/tls.go
@@ -97,16 +97,11 @@ func NewTLSHTTPClient(cert, key, ca, commonName string, disableKeepAlives bool) 
 		log.Panicf("failed to load API client certificates: %s", err)
 	}
 
-	keepAlive := 30 * time.Second
-	if disableKeepAlives {
-		keepAlive = -1 * time.Second
-	}
-
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
-			KeepAlive: keepAlive,
+			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,


### PR DESCRIPTION
# Description

This PR makes keepalive connection between cloud_controller_ng and syslog-binding-cache configurable. Disabling keepalive probes will result in different VMs being called when polling the cloud controller for syslog-binding information.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
