### PR TITLE
OTel Collector gRPC listens on port 3462

### DIFF
--- a/jobs/otel-collector-windows/spec
+++ b/jobs/otel-collector-windows/spec
@@ -17,7 +17,7 @@ properties:
     default: true
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
-    default: 4317
+    default: 3462
   ingress.grpc.tls.ca_cert:
     description: "CA root required for key/cert verification in gRPC ingress"
   ingress.grpc.tls.cert:

--- a/jobs/otel-collector/spec
+++ b/jobs/otel-collector/spec
@@ -18,7 +18,7 @@ properties:
     default: true
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
-    default: 4317
+    default: 3462
   ingress.grpc.tls.ca_cert:
     description: "CA root required for key/cert verification in gRPC ingress"
   ingress.grpc.tls.cert:


### PR DESCRIPTION
# Description

- Switching the default from the standard OTel Collector port to instead use port 3462.
- The new default port is a natural extension of the existing loggregator agent suite port range.

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
