### PR TITLE
Reserve metric exporter name prefix

### DIFF
--- a/jobs/otel-collector-windows/templates/config.yml.erb
+++ b/jobs/otel-collector-windows/templates/config.yml.erb
@@ -1,12 +1,14 @@
 <%=
-otlp_grpc_endpoint = "127.0.0.1:#{p('ingress.grpc.port')}"
+if p('metric_exporters').keys.any?{|k| k.include?('/cf-internal')}
+  raise 'Metric exporters cannot be defined under cf-internal namespace'
+end
 
 config = {
   "receivers"=> {
     "otlp"=>{
       "protocols"=>{
         "grpc"=>{
-          "endpoint"=>otlp_grpc_endpoint,
+          "endpoint"=>"127.0.0.1:#{p('ingress.grpc.port')}",
           "tls"=>{
             "client_ca_file"=>"/var/vcap/jobs/otel-collector-windows/config/certs/otel-collector-ca.crt",
              "cert_file"=>"/var/vcap/jobs/otel-collector-windows/config/certs/otel-collector.crt",

--- a/jobs/otel-collector/templates/config.yml.erb
+++ b/jobs/otel-collector/templates/config.yml.erb
@@ -1,12 +1,14 @@
 <%=
-otlp_grpc_endpoint = "127.0.0.1:#{p('ingress.grpc.port')}"
+if p('metric_exporters').keys.any?{|k| k.include?('/cf-internal')}
+  raise 'Metric exporters cannot be defined under cf-internal namespace'
+end
 
 config = {
   "receivers"=> {
     "otlp"=>{
       "protocols"=>{
         "grpc"=>{
-          "endpoint"=>otlp_grpc_endpoint,
+          "endpoint"=>"127.0.0.1:#{p('ingress.grpc.port')}",
           "tls"=>{
             "client_ca_file"=>"/var/vcap/jobs/otel-collector/config/certs/otel-collector-ca.crt",
              "cert_file"=>"/var/vcap/jobs/otel-collector/config/certs/otel-collector.crt",


### PR DESCRIPTION
# Description

- Error when rendering OTel Collector config if the component identifier for metric exporters contains '/cf-internal'.
- Reserving this name prefix for potential later use.

Sample deployment time failure:

```
Task 83 | 02:33:18 | Error: Unable to render instance groups for deployment. Errors are:
  - Unable to render jobs for instance group 'windows2019-cell'. Errors are:
    - Unable to render templates for job 'otel-collector-windows'. Errors are:
      - Error filling in template 'config.yml.erb' (line 3: Metric exporters cannot be defined under cf-internal namespace)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
