### PR TITLE
change default otel-collector grpc port

### DIFF
--- a/jobs/otel-collector/spec
+++ b/jobs/otel-collector/spec
@@ -18,7 +18,7 @@ properties:
     default: true
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
-    default: 3462
+    default: 9100
   ingress.grpc.tls.ca_cert:
     description: "CA root required for key/cert verification in gRPC ingress"
   ingress.grpc.tls.cert:


### PR DESCRIPTION
we've reclaimed 9100 from system-metrics-agent to use as our ingress port. It will be reserved for us on tcp-router already, which is nice.

3462 was not going to be reserved for use on tcp-router

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes