### PR TITLE
add otel collector service telemetry metrics

### DIFF
--- a/jobs/otel-collector-windows/spec
+++ b/jobs/otel-collector-windows/spec
@@ -25,11 +25,11 @@ properties:
     description: "TLS server certificate for gRPC ingress"
   ingress.grpc.tls.key:
     description: "TLS server key for gRPC ingress"
-  service.telemetry.metrics.level:
-    description: "Level of metrics otel-collector exposes about itself"
+  telemetry.metrics.level:
+    description: "Level of metrics the collector exposes about itself"
     default: "basic"
-  service.telemetry.metrics.port:
-    description: "Port to serve otel-collector's internal metrics"
+  telemetry.metrics.port:
+    description: "Port to serve the collector's internal metrics"
     default: 14830
   metric_exporters:
     description: "Exporter configuration for aggregate metric egress"

--- a/jobs/otel-collector-windows/spec
+++ b/jobs/otel-collector-windows/spec
@@ -7,6 +7,7 @@ templates:
   otel-collector.crt.erb: config/certs/otel-collector.crt
   otel-collector.key.erb: config/certs/otel-collector.key
   otel-collector-ca.crt.erb: config/certs/otel-collector-ca.crt
+  prom_scraper_config.yml.erb: config/prom_scraper_config.yml
 
 packages:
 - otel-collector-windows
@@ -24,6 +25,12 @@ properties:
     description: "TLS server certificate for gRPC ingress"
   ingress.grpc.tls.key:
     description: "TLS server key for gRPC ingress"
+  service.telemetry.metrics.level:
+    description: "Level of metrics otel-collector exposes about itself"
+    default: "basic"
+  service.telemetry.metrics.port:
+    description: "Port to serve otel-collector's internal metrics"
+    default: 14830
   metric_exporters:
     description: "Exporter configuration for aggregate metric egress"
     default: {}

--- a/jobs/otel-collector-windows/spec
+++ b/jobs/otel-collector-windows/spec
@@ -18,7 +18,7 @@ properties:
     default: true
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
-    default: 3462
+    default: 9100
   ingress.grpc.tls.ca_cert:
     description: "CA root required for key/cert verification in gRPC ingress"
   ingress.grpc.tls.cert:

--- a/jobs/otel-collector-windows/templates/config.yml.erb
+++ b/jobs/otel-collector-windows/templates/config.yml.erb
@@ -25,7 +25,12 @@ config = {
   },
   "exporters"=>metric_exporters,
   "service"=>{
-    "telemetry"=>{"metrics"=>{"level"=>"none"}},
+    "telemetry"=>{
+      "metrics"=>{
+        "level"=>p('service.telemetry.metrics.level'),
+        "address"=>"127.0.0.1:#{p('service.telemetry.metrics.port')}"
+      }
+    },
     "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}}
   }
 }

--- a/jobs/otel-collector-windows/templates/config.yml.erb
+++ b/jobs/otel-collector-windows/templates/config.yml.erb
@@ -27,8 +27,8 @@ config = {
   "service"=>{
     "telemetry"=>{
       "metrics"=>{
-        "level"=>p('service.telemetry.metrics.level'),
-        "address"=>"127.0.0.1:#{p('service.telemetry.metrics.port')}"
+        "level"=>p('telemetry.metrics.level'),
+        "address"=>"127.0.0.1:#{p('telemetry.metrics.port')}"
       }
     },
     "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}}

--- a/jobs/otel-collector-windows/templates/prom_scraper_config.yml.erb
+++ b/jobs/otel-collector-windows/templates/prom_scraper_config.yml.erb
@@ -1,3 +1,4 @@
+<% if p('enabled') %>
 ---
 port: <%= p("service.telemetry.metrics.port") %>
 source_id: "otel-collector"
@@ -5,3 +6,4 @@ instance_id: <%= spec.id || spec.index.to_s %>
 scheme: http
 labels:
   origin: otel-collector
+<% end %>

--- a/jobs/otel-collector-windows/templates/prom_scraper_config.yml.erb
+++ b/jobs/otel-collector-windows/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,6 @@
 <% if p('enabled') %>
 ---
-port: <%= p("service.telemetry.metrics.port") %>
+port: <%= p("telemetry.metrics.port") %>
 source_id: "otel-collector"
 instance_id: <%= spec.id || spec.index.to_s %>
 scheme: http

--- a/jobs/otel-collector-windows/templates/prom_scraper_config.yml.erb
+++ b/jobs/otel-collector-windows/templates/prom_scraper_config.yml.erb
@@ -1,0 +1,7 @@
+---
+port: <%= p("service.telemetry.metrics.port") %>
+source_id: "otel-collector"
+instance_id: <%= spec.id || spec.index.to_s %>
+scheme: http
+labels:
+  origin: otel-collector

--- a/jobs/otel-collector/spec
+++ b/jobs/otel-collector/spec
@@ -8,6 +8,7 @@ templates:
   otel-collector.crt.erb: config/certs/otel-collector.crt
   otel-collector.key.erb: config/certs/otel-collector.key
   otel-collector-ca.crt.erb: config/certs/otel-collector-ca.crt
+  prom_scraper_config.yml.erb: config/prom_scraper_config.yml
 
 packages:
 - otel-collector
@@ -25,6 +26,12 @@ properties:
     description: "TLS server certificate for gRPC ingress"
   ingress.grpc.tls.key:
     description: "TLS server key for gRPC ingress"
+  service.telemetry.metrics.level:
+    description: "Level of metrics otel-collector exposes about itself"
+    default: "basic"
+  service.telemetry.metrics.port:
+    description: "Port to serve otel-collector's internal metrics"
+    default: 14830
   metric_exporters:
     description: "Exporter configuration for aggregate metric egress"
     default: {}

--- a/jobs/otel-collector/spec
+++ b/jobs/otel-collector/spec
@@ -26,11 +26,11 @@ properties:
     description: "TLS server certificate for gRPC ingress"
   ingress.grpc.tls.key:
     description: "TLS server key for gRPC ingress"
-  service.telemetry.metrics.level:
-    description: "Level of metrics otel-collector exposes about itself"
+  telemetry.metrics.level:
+    description: "Level of metrics the collector exposes about itself"
     default: "basic"
-  service.telemetry.metrics.port:
-    description: "Port to serve otel-collector's internal metrics"
+  telemetry.metrics.port:
+    description: "Port to serve the collector's internal metrics"
     default: 14830
   metric_exporters:
     description: "Exporter configuration for aggregate metric egress"

--- a/jobs/otel-collector/templates/config.yml.erb
+++ b/jobs/otel-collector/templates/config.yml.erb
@@ -25,7 +25,12 @@ config = {
   },
   "exporters"=>metric_exporters,
   "service"=>{
-    "telemetry"=>{"metrics"=>{"level"=>"none"}},
+    "telemetry"=>{
+      "metrics"=>{
+        "level"=>p('service.telemetry.metrics.level'),
+        "address"=>"127.0.0.1:#{p('service.telemetry.metrics.port')}"
+      }
+    },
     "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}}
   }
 }

--- a/jobs/otel-collector/templates/config.yml.erb
+++ b/jobs/otel-collector/templates/config.yml.erb
@@ -27,8 +27,8 @@ config = {
   "service"=>{
     "telemetry"=>{
       "metrics"=>{
-        "level"=>p('service.telemetry.metrics.level'),
-        "address"=>"127.0.0.1:#{p('service.telemetry.metrics.port')}"
+        "level"=>p('telemetry.metrics.level'),
+        "address"=>"127.0.0.1:#{p('telemetry.metrics.port')}"
       }
     },
     "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}}

--- a/jobs/otel-collector/templates/prom_scraper_config.yml.erb
+++ b/jobs/otel-collector/templates/prom_scraper_config.yml.erb
@@ -1,3 +1,4 @@
+<% if p('enabled') %>
 ---
 port: <%= p("service.telemetry.metrics.port") %>
 source_id: "otel-collector"
@@ -5,3 +6,4 @@ instance_id: <%= spec.id || spec.index.to_s %>
 scheme: http
 labels:
   origin: otel-collector
+<% end %>

--- a/jobs/otel-collector/templates/prom_scraper_config.yml.erb
+++ b/jobs/otel-collector/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,6 @@
 <% if p('enabled') %>
 ---
-port: <%= p("service.telemetry.metrics.port") %>
+port: <%= p("telemetry.metrics.port") %>
 source_id: "otel-collector"
 instance_id: <%= spec.id || spec.index.to_s %>
 scheme: http

--- a/jobs/otel-collector/templates/prom_scraper_config.yml.erb
+++ b/jobs/otel-collector/templates/prom_scraper_config.yml.erb
@@ -1,0 +1,7 @@
+---
+port: <%= p("service.telemetry.metrics.port") %>
+source_id: "otel-collector"
+instance_id: <%= spec.id || spec.index.to_s %>
+scheme: http
+labels:
+  origin: otel-collector


### PR DESCRIPTION
Configure a prometheus endpoint which serves metrics about the otel-collector itself. Also adds a prom_scraper_config so promscraper scrapes the metrics.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

