### PR TITLE
Allow metric exporters to be provided as a string

### DIFF
--- a/jobs/otel-collector-windows/templates/config.yml.erb
+++ b/jobs/otel-collector-windows/templates/config.yml.erb
@@ -1,5 +1,9 @@
 <%=
-if p('metric_exporters').keys.any?{|k| k.include?('/cf-internal')}
+metric_exporters = p('metric_exporters')
+unless metric_exporters.respond_to?(:keys)
+  metric_exporters = YAML::load(metric_exporters)
+end
+if metric_exporters.keys.any?{|k| k.include?('/cf-internal')}
   raise 'Metric exporters cannot be defined under cf-internal namespace'
 end
 
@@ -19,10 +23,10 @@ config = {
       }
     }
   },
-  "exporters"=>p('metric_exporters'),
+  "exporters"=>metric_exporters,
   "service"=>{
     "telemetry"=>{"metrics"=>{"level"=>"none"}},
-    "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>p('metric_exporters').keys}}
+    "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}}
   }
 }
 

--- a/jobs/otel-collector/templates/config.yml.erb
+++ b/jobs/otel-collector/templates/config.yml.erb
@@ -1,5 +1,9 @@
 <%=
-if p('metric_exporters').keys.any?{|k| k.include?('/cf-internal')}
+metric_exporters = p('metric_exporters')
+unless metric_exporters.respond_to?(:keys)
+  metric_exporters = YAML::load(metric_exporters)
+end
+if metric_exporters.keys.any?{|k| k.include?('/cf-internal')}
   raise 'Metric exporters cannot be defined under cf-internal namespace'
 end
 
@@ -19,10 +23,10 @@ config = {
       }
     }
   },
-  "exporters"=>p('metric_exporters'),
+  "exporters"=>metric_exporters,
   "service"=>{
     "telemetry"=>{"metrics"=>{"level"=>"none"}},
-    "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>p('metric_exporters').keys}}
+    "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}}
   }
 }
 


### PR DESCRIPTION
# Description

Allow metric exporters to be provided as a string (or as a hash as previously).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

Manually deployed with exporters defined as strings and hashes and observed successful deployment.

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
