### PR TITLE
Fix otel-collector-windows packaging script

### DIFF
--- a/packages/otel-collector-windows/packaging
+++ b/packages/otel-collector-windows/packaging
@@ -1,4 +1,4 @@
-. .\exiter.ps1
+. ./exiter.ps1
 . C:\var\vcap\packages\golang-1.20-windows\bosh\compile.ps1
 $env:CGO_ENABLED="0"
 


### PR DESCRIPTION
# Description

- PR #360 changed the otel-collector-windows packaging script to use Windows-style backslashes as path delimiters
- This isn't actually desirable everywhere because the first line of the packaging script exists to prevent an error when exporting a BOSH release and attempting to compile this Windows package on a Linux instance

Fixes:
```
.exiter.ps1: No such file or directory
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
