### PR TITLE
chore(cmd/forwarder-agent): do not forward Timers

### DIFF
--- a/src/cmd/forwarder-agent/app/forwarder_agent_test.go
+++ b/src/cmd/forwarder-agent/app/forwarder_agent_test.go
@@ -343,6 +343,7 @@ var _ = Describe("App", func() {
 			},
 			Entry("drops logs", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Log{}}),
 			Entry("drops events", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Event{}}),
+			Entry("drops timers", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Timer{}}),
 		)
 
 		It("forwards counters", func() {
@@ -366,17 +367,5 @@ var _ = Describe("App", func() {
 			metric := req.ResourceMetrics[0].ScopeMetrics[0].Metrics[0]
 			Expect(metric.GetName()).To(Equal(name))
 		})
-
-		It("forwards timers", func() {
-			name := "test-timer-name"
-			ingressClient.EmitTimer(name, time.Time{}, time.Time{})
-
-			var req *colmetricspb.ExportMetricsServiceRequest
-			Eventually(otelServer.requests).Should(Receive(&req))
-
-			metric := req.ResourceMetrics[0].ScopeMetrics[0].Metrics[0]
-			Expect(metric.GetName()).To(Equal(name))
-		})
-
 	})
 })


### PR DESCRIPTION
# Description

Our current method of converting Timer envelopes to single event Histograms to send to an OTel Collector is not ideal. While we think more deeply about how to do this conversion, we want to rip out the conversion code so no one starts depending on this format.

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
