### PR TITLE
chore(otel-collector): use non-GA version

### DIFF
--- a/src/otel-collector/config.yaml
+++ b/src/otel-collector/config.yaml
@@ -4,6 +4,7 @@ dist:
   description: Cloud Foundry OpenTelemetry Collector
   otelcol_version: 0.82.0
   output_path: otel-collector
+  version: 0.1.0
 
 exporters:
 - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.82.0

--- a/src/otel-collector/main.go
+++ b/src/otel-collector/main.go
@@ -18,7 +18,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "cf-otel-collector",
 		Description: "Cloud Foundry OpenTelemetry Collector",
-		Version:     "1.0.0",
+		Version:     "0.1.0",
 	}
 
 	if err := run(otelcol.CollectorSettings{BuildInfo: info, Factories: factories}); err != nil {


### PR DESCRIPTION
Set the version of our OTel Collector distribution to 0.1.0 to indicate that it is experimental.