### PR TITLE
Prevent prometheus exporter from claiming BBS API port

### DIFF
--- a/jobs/otel-collector/templates/config.yml.erb
+++ b/jobs/otel-collector/templates/config.yml.erb
@@ -6,6 +6,9 @@ end
 if metric_exporters.keys.any?{|k| k.include?('/cf-internal')}
   raise 'Metric exporters cannot be defined under cf-internal namespace'
 end
+if metric_exporters.any?{|k, v| k.start_with?('prometheus') && v['endpoint'] && v['endpoint'].end_with?(':8889')}
+  raise 'Cannot define prometheus exporter listening on port 8889 (reserved for BBS API port)'
+end
 
 config = {
   "receivers"=> {


### PR DESCRIPTION
## Description

- When configuring exporters that listen on a port (currently only the promtheus exporter) it is possible to choose a port that conflicts with a system component port.
- A severe version of this is if the operator chooses the port reserved for the BBS API (diego.bbs.listen_addr).
- Because the BBS does not listen on the API port until it holds the lock as the active node, this change can take the BBS as a whole offline.
- If the BBS is subsequently changed to be more resilient to this case then we can remove this check.

Currently the port is specified as hard coded, though this could be a property or a diego property retrieved over bosh links.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
