### PR TITLE
Feat(Forwarder Agent): Add a counter to track drops from egress diodes

### DIFF
--- a/src/cmd/forwarder-agent/app/forwarder_agent_test.go
+++ b/src/cmd/forwarder-agent/app/forwarder_agent_test.go
@@ -367,5 +367,19 @@ var _ = Describe("App", func() {
 			metric := req.ResourceMetrics[0].ScopeMetrics[0].Metrics[0]
 			Expect(metric.GetName()).To(Equal(name))
 		})
+
+		It("emits an expired metric", func() {
+			et := map[string]string{
+				"protocol":    "otelcol",
+				"destination": otelServer.addr,
+			}
+
+			Eventually(agentMetrics.HasMetric).WithArguments("egress_expired_total", et).Should(BeTrue())
+
+			m := agentMetrics.GetMetric("egress_expired_total", et)
+			for k, v := range et {
+				Expect(m.Opts.ConstLabels).To(HaveKeyWithValue(k, v))
+			}
+		})
 	})
 })


### PR DESCRIPTION
# Description

Emit a metric, `egress_expired_total`, per Forwarder Agent egress destination to track the number of envelopes dropped from that designation's diode.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
