### PR TITLE
Operators can suppress warnings for invalid drains

### DIFF
--- a/jobs/loggr-syslog-agent/spec
+++ b/jobs/loggr-syslog-agent/spec
@@ -160,3 +160,7 @@ properties:
   logging.format.timestamp:
     description: "Format for timestamp in component logs. Valid values are 'deprecated' and 'rfc3339'."
     default: "deprecated"
+
+  warn_on_invalid_drains:
+    description: "Whether to output log warnings on invalid drains"
+    default: true

--- a/jobs/loggr-syslog-agent/templates/bpm.yml.erb
+++ b/jobs/loggr-syslog-agent/templates/bpm.yml.erb
@@ -36,6 +36,7 @@
       "DEBUG_METRICS" => "#{p("metrics.debug")}",
       "PPROF_PORT" => "#{p("metrics.pprof_port")}",
       "USE_RFC3339" => "#{p("logging.format.timestamp") == "rfc3339"}",
+      "WARN_ON_INVALID_DRAINS" => "#{p("warn_on_invalid_drains")}",
     }
   }
   if_p("drain_cipher_suites") do | ciphers |

--- a/src/cmd/syslog-agent/app/config.go
+++ b/src/cmd/syslog-agent/app/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	DrainTrustedCAFile   string        `env:"DRAIN_TRUSTED_CA_FILE,  report"`
 	DefaultDrainMetadata bool          `env:"DEFAULT_DRAIN_METADATA, report"`
 	IdleDrainTimeout     time.Duration `env:"IDLE_DRAIN_TIMEOUT, report"`
+	WarnOnInvalidDrains  bool          `env:"WARN_ON_INVALID_DRAINS,    report"`
 
 	GRPC          GRPC
 	Cache         Cache

--- a/src/cmd/syslog-agent/app/syslog_agent.go
+++ b/src/cmd/syslog-agent/app/syslog_agent.go
@@ -110,6 +110,7 @@ func NewSyslogAgent(
 			&cfg.Cache.Blacklist,
 			bindings.NewBindingFetcher(cfg.BindingsPerAppLimit, cacheClient, m, l),
 			m,
+			cfg.WarnOnInvalidDrains,
 			l,
 		)
 		cupsFetcher = bindings.NewDrainParamParser(cupsFetcher, cfg.DefaultDrainMetadata)

--- a/src/pkg/ingress/bindings/filtered_binding_fetcher.go
+++ b/src/pkg/ingress/bindings/filtered_binding_fetcher.go
@@ -26,12 +26,13 @@ type metricsClient interface {
 type FilteredBindingFetcher struct {
 	ipChecker         IPChecker
 	br                binding.Fetcher
+	warn              bool
 	logger            *log.Logger
 	invalidDrains     metrics.Gauge
 	blacklistedDrains metrics.Gauge
 }
 
-func NewFilteredBindingFetcher(c IPChecker, b binding.Fetcher, m metricsClient, lc *log.Logger) *FilteredBindingFetcher {
+func NewFilteredBindingFetcher(c IPChecker, b binding.Fetcher, m metricsClient, warn bool, lc *log.Logger) *FilteredBindingFetcher {
 	opt := metrics.WithMetricLabels(map[string]string{"unit": "total"})
 
 	invalidDrains := m.NewGauge(
@@ -44,10 +45,10 @@ func NewFilteredBindingFetcher(c IPChecker, b binding.Fetcher, m metricsClient, 
 		"Count of blacklisted drains encountered in last binding fetch.",
 		opt,
 	)
-
 	return &FilteredBindingFetcher{
 		ipChecker:         c,
 		br:                b,
+		warn:              warn,
 		logger:            lc,
 		invalidDrains:     invalidDrains,
 		blacklistedDrains: blacklistedDrains,
@@ -71,7 +72,7 @@ func (f *FilteredBindingFetcher) FetchBindings() ([]syslog.Binding, error) {
 		u, err := url.Parse(b.Drain.Url)
 		if err != nil {
 			invalidDrains += 1
-			f.logger.Printf("Cannot parse syslog drain url for application %s", b.AppId)
+			f.printWarning("Cannot parse syslog drain url for application %s", b.AppId)
 			continue
 		}
 
@@ -80,20 +81,20 @@ func (f *FilteredBindingFetcher) FetchBindings() ([]syslog.Binding, error) {
 		anonymousUrl.RawQuery = ""
 
 		if invalidScheme(u.Scheme) {
-			f.logger.Printf("Invalid scheme %s in syslog drain url %s for application %s", u.Scheme, anonymousUrl.String(), b.AppId)
+			f.printWarning("Invalid scheme %s in syslog drain url %s for application %s", u.Scheme, anonymousUrl.String(), b.AppId)
 			continue
 		}
 
 		if len(u.Host) == 0 {
 			invalidDrains += 1
-			f.logger.Printf("No hostname found in syslog drain url %s for application %s", anonymousUrl.String(), b.AppId)
+			f.printWarning("No hostname found in syslog drain url %s for application %s", anonymousUrl.String(), b.AppId)
 			continue
 		}
 
 		ip, err := f.ipChecker.ResolveAddr(u.Host)
 		if err != nil {
 			invalidDrains += 1
-			f.logger.Printf("Cannot resolve ip address for syslog drain with url %s for application %s", anonymousUrl.String(), b.AppId)
+			f.printWarning("Cannot resolve ip address for syslog drain with url %s for application %s", anonymousUrl.String(), b.AppId)
 			continue
 		}
 
@@ -101,7 +102,7 @@ func (f *FilteredBindingFetcher) FetchBindings() ([]syslog.Binding, error) {
 		if err != nil {
 			invalidDrains += 1
 			blacklistedDrains += 1
-			f.logger.Printf("Resolved ip address for syslog drain with url %s for application %s is blacklisted", anonymousUrl.String(), b.AppId)
+			f.printWarning("Resolved ip address for syslog drain with url %s for application %s is blacklisted", anonymousUrl.String(), b.AppId)
 			continue
 		}
 
@@ -111,6 +112,12 @@ func (f *FilteredBindingFetcher) FetchBindings() ([]syslog.Binding, error) {
 	f.blacklistedDrains.Set(blacklistedDrains)
 	f.invalidDrains.Set(invalidDrains)
 	return newBindings, nil
+}
+
+func (f FilteredBindingFetcher) printWarning(format string, v ...any) {
+	if f.warn {
+		f.logger.Printf(format, v...)
+	}
 }
 
 func invalidScheme(scheme string) bool {


### PR DESCRIPTION
# Description

- In 62f65b38 we added log messages for invalid syslog drains to the syslog agent.
- Allow operators to suppress these messages if they would prefer not to have them present in the syslog agent logs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
