### PR TITLE
Operators can suppress warnings for invalid drains (Windows)

### DIFF
--- a/jobs/loggr-syslog-agent-windows/monit
+++ b/jobs/loggr-syslog-agent-windows/monit
@@ -44,8 +44,9 @@
       "METRICS_CERT_FILE_PATH" => "#{certs_dir}/metrics.crt",
       "METRICS_KEY_FILE_PATH" => "#{certs_dir}/metrics.key",
       "DEBUG_METRICS" => "#{p("metrics.debug")}",
-     "PPROF_PORT" => "#{p("metrics.pprof_port")}",
+      "PPROF_PORT" => "#{p("metrics.pprof_port")}",
       "USE_RFC3339" => "#{p("logging.format.timestamp") == "rfc3339"}",
+      "WARN_ON_INVALID_DRAINS" => "#{p("warn_on_invalid_drains")}",
     }
   }
   if_p("drain_cipher_suites") do | ciphers |

--- a/jobs/loggr-syslog-agent-windows/spec
+++ b/jobs/loggr-syslog-agent-windows/spec
@@ -123,3 +123,7 @@ properties:
   logging.format.timestamp:
     description: "Format for timestamp in component logs. Valid values are 'deprecated' and 'rfc3339'."
     default: "deprecated"
+
+  warn_on_invalid_drains:
+    description: "Whether to output log warnings on invalid drains"
+    default: true


### PR DESCRIPTION
# Description

In #422 we made warnings for invalid syslog drains configurable but neglected to add the same property to the loggr-syslog-agent-windows job.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
