### PR TITLE
Legacy syslog bindings code cleanup

### DIFF
--- a/src/cmd/syslog-agent/app/syslog_agent_mtls_test.go
+++ b/src/cmd/syslog-agent/app/syslog_agent_mtls_test.go
@@ -298,12 +298,8 @@ func (f *fakeBindingCache) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/v2/bindings":
 		results, err = json.Marshal(f.bindings)
-	case "/bindings":
-		results, err = json.Marshal(binding.ToLegacyBindings(f.bindings))
 	case "/v2/aggregate":
 		results, err = json.Marshal(f.aggregate)
-	case "/aggregate":
-		results, err = json.Marshal(binding.ToLegacyBindings(f.aggregate))
 	default:
 		w.WriteHeader(500)
 		return

--- a/src/cmd/syslog-binding-cache/app/syslog_binding_cache.go
+++ b/src/cmd/syslog-binding-cache/app/syslog_binding_cache.go
@@ -53,16 +53,13 @@ func (sbc *SyslogBindingCache) Run() {
 		go func() { sbc.log.Println("PPROF SERVER STOPPED " + sbc.pprofServer.ListenAndServe().Error()) }()
 	}
 	store := binding.NewStore(sbc.metrics)
-	legacyStore := binding.NewLegacyStore()
 	aggregateStore := binding.NewAggregateStore(sbc.config.AggregateDrainsFile)
-	poller := binding.NewPoller(sbc.apiClient(), sbc.config.APIPollingInterval, store, legacyStore, sbc.metrics, sbc.log)
+	poller := binding.NewPoller(sbc.apiClient(), sbc.config.APIPollingInterval, store, sbc.metrics, sbc.log)
 
 	go poller.Poll()
 
 	router := chi.NewRouter()
-	router.Get("/bindings", cache.LegacyHandler(legacyStore))
 	router.Get("/v2/bindings", cache.Handler(store))
-	router.Get("/aggregate", cache.LegacyAggregateHandler(aggregateStore))
 	router.Get("/v2/aggregate", cache.AggregateHandler(aggregateStore))
 
 	sbc.startServer(router)

--- a/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
+++ b/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
@@ -244,56 +244,6 @@ var _ = Describe("App", func() {
 			}))
 	})
 
-	It("has an HTTP endpoint that returns legacy aggregate drains", func() {
-		addr := fmt.Sprintf("https://localhost:%d/aggregate", sbcPort)
-
-		var resp *http.Response
-		Eventually(func() error {
-			var err error
-			resp, err = client.Get(addr)
-			return err
-		}).Should(Succeed())
-		defer resp.Body.Close()
-
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-
-		body, err := io.ReadAll(resp.Body)
-		Expect(err).ToNot(HaveOccurred())
-
-		var result []binding.LegacyBinding
-		err = json.Unmarshal(body, &result)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(result).To(HaveLen(1))
-		Expect(result[0].Drains).To(ConsistOf("syslog://test-hostname:1000", "syslog://test2:1000"))
-	})
-
-	It("has an HTTP endpoint that returns legacy bindings", func() {
-		addr := fmt.Sprintf("https://localhost:%d/bindings", sbcPort)
-
-		var resp *http.Response
-		Eventually(func() error {
-			var err error
-			resp, err = client.Get(addr)
-			return err
-		}).Should(Succeed())
-		defer resp.Body.Close()
-
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-
-		body, err := io.ReadAll(resp.Body)
-		Expect(err).ToNot(HaveOccurred())
-
-		var results []binding.LegacyBinding
-		err = json.Unmarshal(body, &results)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(results).To(HaveLen(2))
-		result1 := binding.LegacyBinding{AppID: "app-id-1", Drains: []string{"syslog://drain-a", "syslog://drain-b"}, Hostname: "org.space.app-name-1", V2Available: true}
-		result2 := binding.LegacyBinding{AppID: "app-id-2", Drains: []string{"syslog://drain-c", "syslog://drain-d"}, Hostname: "org.space.app-name-2", V2Available: true}
-		Expect(results).Should(ConsistOf(result1, result2))
-	})
-
 	Context("when debug configuration is enabled", func() {
 		BeforeEach(func() {
 			sbcCfg.MetricsServer.DebugMetrics = true

--- a/src/pkg/binding/poller.go
+++ b/src/pkg/binding/poller.go
@@ -13,7 +13,6 @@ type Poller struct {
 	apiClient       client
 	pollingInterval time.Duration
 	store           Setter
-	legacyStore     LegacySetter
 
 	logger                     *log.Logger
 	bindingRefreshErrorCounter metrics.Counter
@@ -22,7 +21,6 @@ type Poller struct {
 
 type client interface {
 	Get(int) (*http.Response, error)
-	LegacyGet(int) (*http.Response, error)
 }
 
 type Credentials struct {
@@ -49,27 +47,15 @@ type AggBinding struct {
 	CA   string `yaml:"ca"`
 }
 
-type LegacyBinding struct {
-	AppID       string   `json:"app_id"`
-	Drains      []string `json:"drains"`
-	Hostname    string   `json:"hostname"`
-	V2Available bool     `json:"v2_available"`
-}
-
 type Setter interface {
 	Set(bindings []Binding, bindingCount int)
 }
 
-type LegacySetter interface {
-	Set([]LegacyBinding)
-}
-
-func NewPoller(ac client, pi time.Duration, s Setter, legacyStore LegacySetter, m Metrics, logger *log.Logger) *Poller {
+func NewPoller(ac client, pi time.Duration, s Setter, m Metrics, logger *log.Logger) *Poller {
 	p := &Poller{
 		apiClient:       ac,
 		pollingInterval: pi,
 		store:           s,
-		legacyStore:     legacyStore,
 		logger:          logger,
 		bindingRefreshErrorCounter: m.NewCounter(
 			"binding_refresh_error",
@@ -103,16 +89,14 @@ func (p *Poller) poll() {
 			return
 		}
 		if resp.StatusCode != http.StatusOK {
-			p.logger.Printf("unexpected response from internal bindings endpoint. status code: %d, falling back to legacy endpoint", resp.StatusCode)
-			p.pollLegacyFallback()
+			p.logger.Printf("unexpected response from internal bindings endpoint. status code: %d", resp.StatusCode)
 			return
 		}
 
 		var aResp apiResponse
 		err = json.NewDecoder(resp.Body).Decode(&aResp)
 		if err != nil {
-			p.logger.Printf("failed to decode JSON: %s, falling back to legacy endpoint", err)
-			p.pollLegacyFallback()
+			p.logger.Printf("failed to decode JSON: %s", err)
 			return
 		}
 
@@ -127,54 +111,6 @@ func (p *Poller) poll() {
 	bindingCount := CalculateBindingCount(bindings)
 	p.lastBindingCount.Set(float64(bindingCount))
 	p.store.Set(bindings, bindingCount)
-	p.legacyStore.Set(ToLegacyBindings(bindings))
-}
-
-func (p *Poller) pollLegacyFallback() {
-	nextID := 0
-	var legacyBindings []LegacyBinding
-
-	for {
-		resp, err := p.apiClient.LegacyGet(nextID)
-		if err != nil {
-			p.bindingRefreshErrorCounter.Add(1)
-			p.logger.Printf("failed to get page %d from internal legacy bindings endpoint: %s", nextID, err)
-			return
-		}
-		if resp.StatusCode != http.StatusOK {
-			p.logger.Printf("unexpected response from internal legacy bindings endpoint. status code: %d", resp.StatusCode)
-			return
-		}
-
-		var aRespLegacy legacyApiResponse
-		err = json.NewDecoder(resp.Body).Decode(&aRespLegacy)
-		if err != nil {
-			p.logger.Printf("failed to decode legacy JSON: %s", err)
-			return
-		}
-		if aRespLegacy.V5Available {
-			p.logger.Printf("V4 endpoint is deprecated, skipping v4 result parsing.")
-			return
-		}
-		for k, v := range aRespLegacy.Results {
-			legacyBindings = append(legacyBindings, LegacyBinding{
-				AppID:       k,
-				Drains:      v.Drains,
-				Hostname:    v.Hostname,
-				V2Available: true,
-			})
-		}
-		nextID = aRespLegacy.NextID
-
-		if nextID == 0 {
-			break
-		}
-	}
-	bindings := ToBindings(legacyBindings)
-	bindingCount := CalculateBindingCount(bindings)
-	p.lastBindingCount.Set(float64(bindingCount))
-	p.store.Set(bindings, bindingCount)
-	p.legacyStore.Set(legacyBindings)
 }
 
 func CalculateBindingCount(bindings []Binding) int {
@@ -189,66 +125,7 @@ func CalculateBindingCount(bindings []Binding) int {
 	return len(apps)
 }
 
-type legacyMold struct {
-	drains   []string
-	hostname string
-}
-
-func ToBindings(legacyBindings []LegacyBinding) []Binding {
-	var bindings []Binding
-	var remodel = make(map[string]Credentials)
-	for _, lb := range legacyBindings {
-		for _, d := range lb.Drains {
-			if val, ok := remodel[d]; ok {
-				app := App{AppID: lb.AppID, Hostname: lb.Hostname}
-				remodel[d] = Credentials{Apps: append(val.Apps, app)}
-			} else {
-				app := App{AppID: lb.AppID, Hostname: lb.Hostname}
-				remodel[d] = Credentials{Apps: []App{app}}
-			}
-		}
-	}
-
-	for url, credentials := range remodel {
-		binding := Binding{Url: url, Credentials: []Credentials{credentials}}
-		bindings = append(bindings, binding)
-	}
-	return bindings
-}
-
-func ToLegacyBindings(bindings []Binding) []LegacyBinding {
-	var legacyBindings []LegacyBinding
-	remodel := make(map[string]legacyMold)
-	for _, b := range bindings {
-		drain := b.Url
-		for _, c := range b.Credentials {
-			for _, a := range c.Apps {
-				if val, ok := remodel[a.AppID]; ok {
-					remodel[a.AppID] = legacyMold{drains: append(val.drains, drain), hostname: a.Hostname}
-				} else {
-					remodel[a.AppID] = legacyMold{drains: []string{drain}, hostname: a.Hostname}
-				}
-			}
-		}
-	}
-
-	for appID, app := range remodel {
-		legacyBinding := LegacyBinding{appID, app.drains, app.hostname, true}
-		legacyBindings = append(legacyBindings, legacyBinding)
-	}
-	return legacyBindings
-}
-
 type apiResponse struct {
 	Results []Binding
 	NextID  int `json:"next_id"`
-}
-
-type legacyApiResponse struct {
-	Results map[string]struct {
-		Drains   []string
-		Hostname string
-	}
-	NextID      int  `json:"next_id"`
-	V5Available bool `json:"v5_available"`
 }

--- a/src/pkg/binding/poller_test.go
+++ b/src/pkg/binding/poller_test.go
@@ -20,22 +20,20 @@ import (
 
 var _ = Describe("Poller", func() {
 	var (
-		apiClient   *fakeAPIClient
-		store       *fakeStore
-		legacyStore *fakeLegacyStore
-		metrics     *metricsHelpers.SpyMetricsRegistry
-		logger      = log.New(GinkgoWriter, "", 0)
+		apiClient *fakeAPIClient
+		store     *fakeStore
+		metrics   *metricsHelpers.SpyMetricsRegistry
+		logger    = log.New(GinkgoWriter, "", 0)
 	)
 
 	BeforeEach(func() {
 		apiClient = newFakeAPIClient()
 		store = newFakeStore()
-		legacyStore = newFakeLegacyStore()
 		metrics = metricsHelpers.NewMetricsRegistry()
 	})
 
 	It("polls for bindings on an interval", func() {
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
+		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, metrics, logger)
 		go p.Poll()
 
 		Eventually(apiClient.called).Should(BeNumerically(">=", 2))
@@ -69,7 +67,7 @@ var _ = Describe("Poller", func() {
 			},
 		}
 
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
+		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, metrics, logger)
 		go p.Poll()
 
 		var expectedBindings []binding.Binding
@@ -96,29 +94,6 @@ var _ = Describe("Poller", func() {
 						Cert: "cert2", Key: "key2", CA: "ca2", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"}},
 					},
 				},
-			},
-		}))
-
-		var expectedLegacyBindings []binding.LegacyBinding
-		Eventually(legacyStore.bindings).Should(Receive(&expectedLegacyBindings))
-		Expect(expectedLegacyBindings).To(ConsistOf([]binding.LegacyBinding{
-			{
-				AppID:       "app-id-0",
-				Drains:      []string{"drain-0", "drain-1"},
-				Hostname:    "app-hostname0",
-				V2Available: true,
-			},
-			{
-				AppID:       "app-id-1",
-				Drains:      []string{"drain-0"},
-				Hostname:    "app-hostname1",
-				V2Available: true,
-			},
-			{
-				AppID:       "app-id-2",
-				Drains:      []string{"drain-0"},
-				Hostname:    "app-hostname2",
-				V2Available: true,
 			},
 		}))
 	})
@@ -167,7 +142,7 @@ var _ = Describe("Poller", func() {
 			},
 		}
 
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
+		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, metrics, logger)
 		go p.Poll()
 
 		var expectedBindings []binding.Binding
@@ -209,40 +184,11 @@ var _ = Describe("Poller", func() {
 			},
 		))
 
-		var expectedLegacyBindings []binding.LegacyBinding
-		Eventually(legacyStore.bindings).Should(Receive(&expectedLegacyBindings))
-		Expect(expectedLegacyBindings).To(ConsistOf([]binding.LegacyBinding{
-			{
-				AppID:       "app-id-0",
-				Drains:      []string{"drain-0"},
-				Hostname:    "app-hostname0",
-				V2Available: true,
-			},
-			{
-				AppID:       "app-id-1",
-				Drains:      []string{"drain-1"},
-				Hostname:    "app-hostname1",
-				V2Available: true,
-			},
-			{
-				AppID:       "app-id-2",
-				Drains:      []string{"drain-2"},
-				Hostname:    "app-hostname2",
-				V2Available: true,
-			},
-			{
-				AppID:       "app-id-3",
-				Drains:      []string{"drain-3"},
-				Hostname:    "app-hostname3",
-				V2Available: true,
-			},
-		}))
-
 		Expect(apiClient.requestedIDs).To(ConsistOf(0, 2))
 	})
 
 	It("tracks the number of API errors", func() {
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
+		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, metrics, logger)
 		go p.Poll()
 
 		apiClient.errors <- errors.New("expected")
@@ -252,161 +198,13 @@ var _ = Describe("Poller", func() {
 		}).Should(BeNumerically("==", 1))
 	})
 
-	It("tracks the number of API errors if fallback fails", func() {
+	It("does not update the stores if the response code is bad", func() {
 		apiClient.statusCode <- 404
-		apiClient.legacyErrors <- errors.New("expected")
 
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
-		go p.Poll()
-
-		Eventually(func() float64 {
-			return metrics.GetMetric("binding_refresh_error", nil).Value()
-		}).Should(BeNumerically("==", 1))
-	})
-
-	It("fetches results with legacy fallback functionality if CAPI v5 endpoint is unavailable", func() {
-
-		apiClient.statusCode <- 404
-		apiClient.legacyBindings <- legacyResponse{
-			Results: map[string]struct {
-				Drains   []string
-				Hostname string
-			}{"app-id-0": {Drains: []string{"drain-0", "drain-1"}, Hostname: "app-hostname0"}},
-		}
-
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
-		go p.Poll()
-
-		var expectedBindings []binding.Binding
-		Eventually(store.bindings).Should(Receive(&expectedBindings))
-		Expect(expectedBindings).To(ConsistOf([]binding.Binding{
-			{
-				Url: "drain-0",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "", Key: "", CA: "", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"}},
-					},
-				},
-			},
-			{
-				Url: "drain-1",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "", Key: "", CA: "", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"}},
-					},
-				},
-			},
-		}))
-
-		var expectedLegacyBindings []binding.LegacyBinding
-		Eventually(legacyStore.bindings).Should(Receive(&expectedLegacyBindings))
-		Expect(expectedLegacyBindings).To(ConsistOf([]binding.LegacyBinding{
-			{
-				AppID:       "app-id-0",
-				Drains:      []string{"drain-0", "drain-1"},
-				Hostname:    "app-hostname0",
-				V2Available: true,
-			},
-		}))
-
-	})
-
-	It("fetches the next page with legacy fallback functionality and stores the result", func() {
-
-		apiClient.statusCode <- 404
-		apiClient.legacyBindings <- legacyResponse{
-			NextID: 2,
-			Results: map[string]struct {
-				Drains   []string
-				Hostname string
-			}{"app-id-0": {Drains: []string{"drain-0", "drain-1"}, Hostname: "app-hostname0"}},
-		}
-		apiClient.legacyBindings <- legacyResponse{
-			Results: map[string]struct {
-				Drains   []string
-				Hostname string
-			}{"app-id-1": {Drains: []string{"drain-1", "drain-2"}, Hostname: "app-hostname1"}},
-		}
-
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
-		go p.Poll()
-
-		var expectedBindings []binding.Binding
-		Eventually(store.bindings).Should(Receive(&expectedBindings))
-		Expect(expectedBindings).To(ConsistOf([]binding.Binding{
-			{
-				Url: "drain-0",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "", Key: "", CA: "", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"}},
-					},
-				},
-			},
-			{
-				Url: "drain-1",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "", Key: "", CA: "", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"},
-							{Hostname: "app-hostname1", AppID: "app-id-1"}},
-					},
-				},
-			},
-			{
-				Url: "drain-2",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "", Key: "", CA: "", Apps: []binding.App{{Hostname: "app-hostname1", AppID: "app-id-1"}},
-					},
-				},
-			},
-		}))
-
-		var expectedLegacyBindings []binding.LegacyBinding
-		Eventually(legacyStore.bindings).Should(Receive(&expectedLegacyBindings))
-		Expect(expectedLegacyBindings).To(ConsistOf([]binding.LegacyBinding{
-			{
-				AppID:       "app-id-0",
-				Drains:      []string{"drain-0", "drain-1"},
-				Hostname:    "app-hostname0",
-				V2Available: true,
-			},
-			{
-				AppID:       "app-id-1",
-				Drains:      []string{"drain-1", "drain-2"},
-				Hostname:    "app-hostname1",
-				V2Available: true,
-			},
-		}))
-
-	})
-
-	It("skips parsing v4 results if CAPI v5 endpoint is unavailable but CAPI is already updated", func() {
-
-		apiClient.statusCode <- 404
-		apiClient.legacyBindings <- legacyResponse{
-			Results: map[string]struct {
-				Drains   []string
-				Hostname string
-			}{"app-id-0": {Drains: []string{"drain-0", "drain-1"}, Hostname: "app-hostname0"}},
-			V5Available: true,
-		}
-
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
+		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, metrics, logger)
 		go p.Poll()
 
 		Eventually(store.bindings).Should(BeEmpty())
-		Eventually(legacyStore.bindings).Should(BeEmpty())
-	})
-
-	It("does not update the stores if both response codes are bad", func() {
-		apiClient.statusCode <- 404
-		apiClient.legacyStatusCode <- 404
-
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
-		go p.Poll()
-
-		Eventually(store.bindings).Should(BeEmpty())
-		Eventually(legacyStore.bindings).Should(BeEmpty())
 	})
 
 	It("tracks the number of bindings returned from CAPI", func() {
@@ -430,7 +228,7 @@ var _ = Describe("Poller", func() {
 				},
 			},
 		}
-		binding.NewPoller(apiClient, time.Hour, store, legacyStore, metrics, logger)
+		binding.NewPoller(apiClient, time.Hour, store, metrics, logger)
 
 		Expect(metrics.GetMetric("last_binding_refresh_count", nil).Value()).
 			To(BeNumerically("==", 2))
@@ -481,160 +279,21 @@ var _ = Describe("Poller", func() {
 		Expect(binding.CalculateBindingCount(multipleBindings)).
 			To(BeNumerically("==", 2))
 	})
-
-	It("tracks the correct transformation to LegacyBindings", func() {
-		noBinding := []binding.Binding{}
-		singleBinding := []binding.Binding{
-			{
-				Url: "drain-0",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "cert0", Key: "key0", CA: "ca0", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"}},
-					},
-				},
-			},
-			{
-				Url: "drain-1",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "cert1", Key: "key1", CA: "ca1", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"}},
-					},
-				},
-			},
-		}
-		multipleBindings := []binding.Binding{
-			{
-				Url: "drain-0",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "cert0", Key: "key0", CA: "ca0", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"}},
-					},
-				},
-			},
-			{
-				Url: "drain-1",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "cert1", Key: "key1", CA: "ca1", Apps: []binding.App{{Hostname: "app-hostname1", AppID: "app-id-1"}},
-					},
-				},
-			},
-		}
-		expectedSingleLegacyBindings := []binding.LegacyBinding{
-			{
-				AppID:       "app-id-0",
-				Drains:      []string{"drain-0", "drain-1"},
-				Hostname:    "app-hostname0",
-				V2Available: true,
-			},
-		}
-		expectedMultiLegacyBindings := []binding.LegacyBinding{
-			{
-				AppID:       "app-id-0",
-				Drains:      []string{"drain-0"},
-				Hostname:    "app-hostname0",
-				V2Available: true,
-			},
-			{
-				AppID:       "app-id-1",
-				Drains:      []string{"drain-1"},
-				Hostname:    "app-hostname1",
-				V2Available: true,
-			},
-		}
-
-		Expect(binding.ToLegacyBindings(noBinding)).To(ConsistOf([]binding.LegacyBinding{}))
-		Expect(binding.ToLegacyBindings(singleBinding)).To(ConsistOf(expectedSingleLegacyBindings))
-		Expect(binding.ToLegacyBindings(multipleBindings)).To(ConsistOf(expectedMultiLegacyBindings))
-
-	})
-
-	It("tracks the correct transformation from LegacyBindings to Bindings", func() {
-		noBinding := []binding.LegacyBinding{}
-		singleLegacyBinding := []binding.LegacyBinding{
-			{
-				AppID:    "app-id-0",
-				Drains:   []string{"drain-0"},
-				Hostname: "app-hostname0",
-			},
-		}
-		multipleLegacyBindings := []binding.LegacyBinding{
-			{
-				AppID:    "app-id-0",
-				Drains:   []string{"drain-0", "drain-1"},
-				Hostname: "app-hostname0",
-			},
-			{
-				AppID:    "app-id-1",
-				Drains:   []string{"drain-1", "drain-2"},
-				Hostname: "app-hostname1",
-			},
-		}
-		expectedSingleBinding := []binding.Binding{
-			{
-				Url: "drain-0",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "", Key: "", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"}},
-					},
-				},
-			},
-		}
-		expectedMultiBindings := []binding.Binding{
-			{
-				Url: "drain-0",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "", Key: "", CA: "", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"}},
-					},
-				},
-			},
-			{
-				Url: "drain-1",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "", Key: "", Apps: []binding.App{{Hostname: "app-hostname0", AppID: "app-id-0"},
-							{Hostname: "app-hostname1", AppID: "app-id-1"}},
-					},
-				},
-			},
-			{
-				Url: "drain-2",
-				Credentials: []binding.Credentials{
-					{
-						Cert: "", Key: "", Apps: []binding.App{{Hostname: "app-hostname1", AppID: "app-id-1"}},
-					},
-				},
-			},
-		}
-
-		Expect(binding.ToBindings(noBinding)).To(ConsistOf([]binding.LegacyBinding{}))
-		Expect(binding.ToBindings(singleLegacyBinding)).To(ConsistOf(expectedSingleBinding))
-		Expect(binding.ToBindings(multipleLegacyBindings)).To(ConsistOf(expectedMultiBindings))
-
-	})
-
 })
 
 type fakeAPIClient struct {
-	numRequests      int64
-	bindings         chan response
-	errors           chan error
-	legacyErrors     chan error
-	legacyBindings   chan legacyResponse
-	statusCode       chan int
-	legacyStatusCode chan int
-	requestedIDs     []int
+	numRequests  int64
+	bindings     chan response
+	errors       chan error
+	statusCode   chan int
+	requestedIDs []int
 }
 
 func newFakeAPIClient() *fakeAPIClient {
 	return &fakeAPIClient{
-		bindings:         make(chan response, 100),
-		legacyBindings:   make(chan legacyResponse, 100),
-		errors:           make(chan error, 100),
-		legacyErrors:     make(chan error, 100),
-		legacyStatusCode: make(chan int, 100),
-		statusCode:       make(chan int, 100),
+		bindings:   make(chan response, 100),
+		errors:     make(chan error, 100),
+		statusCode: make(chan int, 100),
 	}
 }
 
@@ -665,33 +324,6 @@ func (c *fakeAPIClient) Get(nextID int) (*http.Response, error) {
 	return resp, err
 }
 
-func (c *fakeAPIClient) LegacyGet(nextID int) (*http.Response, error) {
-	atomic.AddInt64(&c.numRequests, 1)
-
-	var legacyBinding legacyResponse
-	var statusCode = 200
-	select {
-	case err := <-c.legacyErrors:
-		return nil, err
-	case legacyBinding = <-c.legacyBindings:
-		c.requestedIDs = append(c.requestedIDs, nextID)
-	case injectedStatusCode := <-c.legacyStatusCode:
-		statusCode = injectedStatusCode
-	default:
-	}
-
-	var body []byte
-	b, err := json.Marshal(&legacyBinding)
-	Expect(err).ToNot(HaveOccurred())
-	body = b
-	resp := &http.Response{
-		Body: io.NopCloser(bytes.NewReader(body)),
-	}
-	resp.StatusCode = statusCode
-
-	return resp, nil
-}
-
 func (c *fakeAPIClient) called() int64 {
 	return atomic.LoadInt64(&c.numRequests)
 }
@@ -710,30 +342,7 @@ func (c *fakeStore) Set(b []binding.Binding, bindingCount int) {
 	c.bindings <- b
 }
 
-type fakeLegacyStore struct {
-	bindings chan []binding.LegacyBinding
-}
-
-func newFakeLegacyStore() *fakeLegacyStore {
-	return &fakeLegacyStore{
-		bindings: make(chan []binding.LegacyBinding, 100),
-	}
-}
-
-func (c *fakeLegacyStore) Set(b []binding.LegacyBinding) {
-	c.bindings <- b
-}
-
 type response struct {
 	Results []binding.Binding
 	NextID  int `json:"next_id"`
-}
-
-type legacyResponse struct {
-	Results map[string]struct {
-		Drains   []string
-		Hostname string
-	}
-	NextID      int  `json:"next_id"`
-	V5Available bool `json:"v5_available"`
 }

--- a/src/pkg/binding/store.go
+++ b/src/pkg/binding/store.go
@@ -43,32 +43,6 @@ func (s *Store) Set(bindings []Binding, bindingCount int) {
 	s.mu.Unlock()
 }
 
-type LegacyStore struct {
-	mu             sync.Mutex
-	legacyBindings []LegacyBinding
-}
-
-func NewLegacyStore() *LegacyStore {
-	return &LegacyStore{
-		legacyBindings: make([]LegacyBinding, 0),
-	}
-}
-
-func (s *LegacyStore) Get() []LegacyBinding {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.legacyBindings
-}
-
-func (s *LegacyStore) Set(bindings []LegacyBinding) {
-	if bindings == nil {
-		bindings = []LegacyBinding{}
-	}
-	s.mu.Lock()
-	s.legacyBindings = bindings
-	s.mu.Unlock()
-}
-
 type AggregateStore struct {
 	Drains []Binding
 }
@@ -106,18 +80,4 @@ func NewAggregateStore(drainFileName string) *AggregateStore {
 
 func (store *AggregateStore) Get() []Binding {
 	return store.Drains
-}
-
-func (store *AggregateStore) LegacyGet() []LegacyBinding {
-	var drains []string
-	for _, binding := range store.Drains {
-		drains = append(drains, binding.Url)
-	}
-	return []LegacyBinding{
-		{
-			AppID:       "",
-			Drains:      drains,
-			V2Available: true,
-		},
-	}
 }

--- a/src/pkg/binding/store_test.go
+++ b/src/pkg/binding/store_test.go
@@ -27,28 +27,8 @@ var _ = Describe("Store", func() {
 		Expect(store.Get()).To(Equal(bindings))
 	})
 
-	It("should store and retrieve legacy bindings", func() {
-		legacyStore := binding.NewLegacyStore()
-		bindings := []binding.LegacyBinding{
-			{
-				AppID:    "app-1",
-				Drains:   []string{"drain-1"},
-				Hostname: "host-1",
-			},
-		}
-
-		legacyStore.Set(bindings)
-		Expect(legacyStore.Get()).To(Equal(bindings))
-
-	})
-
 	It("should not return nil bindings", func() {
 		store := binding.NewStore(metricsHelpers.NewMetricsRegistry())
-		Expect(store.Get()).ToNot(BeNil())
-	})
-
-	It("should not return nil legacy bindings", func() {
-		store := binding.NewLegacyStore()
 		Expect(store.Get()).ToNot(BeNil())
 	})
 
@@ -68,25 +48,6 @@ var _ = Describe("Store", func() {
 
 		store.Set(bindings, 1)
 		store.Set(nil, 1)
-
-		storedBindings := store.Get()
-		Expect(storedBindings).ToNot(BeNil())
-		Expect(storedBindings).To(BeEmpty())
-	})
-
-	It("should not allow setting of legacy bindings to nil", func() {
-		store := binding.NewLegacyStore()
-
-		bindings := []binding.LegacyBinding{
-			{
-				AppID:    "app-1",
-				Drains:   []string{"drain-1"},
-				Hostname: "host-1",
-			},
-		}
-
-		store.Set(bindings)
-		store.Set(nil)
 
 		storedBindings := store.Get()
 		Expect(storedBindings).ToNot(BeNil())
@@ -163,14 +124,6 @@ var _ = Describe("Store", func() {
 					CA:   "ca2",
 				},
 				},
-			},
-		))
-		Expect(aggStore.LegacyGet()).To(ConsistOf(
-			binding.LegacyBinding{
-				AppID:       "",
-				Drains:      []string{"syslog://test-hostname:1000", "syslog://test2:1000"},
-				Hostname:    "",
-				V2Available: true,
 			},
 		))
 	})

--- a/src/pkg/cache/client.go
+++ b/src/pkg/cache/client.go
@@ -29,43 +29,12 @@ func (c *CacheClient) Get() ([]binding.Binding, error) {
 	return c.get("v2/bindings")
 }
 
-func (c *CacheClient) LegacyGet() ([]binding.LegacyBinding, error) {
-	return c.legacyGet("bindings")
-}
-
 func (c *CacheClient) GetAggregate() ([]binding.Binding, error) {
 	return c.get("v2/aggregate")
 }
 
-func (c *CacheClient) GetLegacyAggregate() ([]binding.LegacyBinding, error) {
-	return c.legacyGet("aggregate")
-}
-
 func (c *CacheClient) get(path string) ([]binding.Binding, error) {
 	var bindings []binding.Binding
-	resp, err := c.h.Get(fmt.Sprintf("%s/"+path, c.cacheAddr))
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected http response from binding cache: %d", resp.StatusCode)
-	}
-
-	err = json.NewDecoder(resp.Body).Decode(&bindings)
-	if err != nil {
-		return nil, err
-	}
-
-	return bindings, nil
-}
-
-func (c *CacheClient) legacyGet(path string) ([]binding.LegacyBinding, error) {
-	var bindings []binding.LegacyBinding
 	resp, err := c.h.Get(fmt.Sprintf("%s/"+path, c.cacheAddr))
 	if err != nil {
 		return nil, err

--- a/src/pkg/cache/client_test.go
+++ b/src/pkg/cache/client_test.go
@@ -51,27 +51,6 @@ var _ = Describe("Client", func() {
 		Expect(spyHTTPClient.requestURL).To(Equal("https://cache.address.com/v2/bindings"))
 	})
 
-	It("returns legacy bindings from the cache", func() {
-		bindings := []binding.LegacyBinding{
-			{
-				AppID:       "app-id-1",
-				Drains:      []string{"drain-1"},
-				Hostname:    "host-1",
-				V2Available: true,
-			},
-		}
-
-		j, err := json.Marshal(bindings)
-		Expect(err).ToNot(HaveOccurred())
-		spyHTTPClient.response = &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader(j)),
-		}
-
-		Expect(client.LegacyGet()).To(Equal(bindings))
-		Expect(spyHTTPClient.requestURL).To(Equal("https://cache.address.com/bindings"))
-	})
-
 	It("returns aggregate drains from the cache", func() {
 		bindings := []binding.Binding{
 			{
@@ -97,26 +76,6 @@ var _ = Describe("Client", func() {
 		Expect(spyHTTPClient.requestURL).To(Equal("https://cache.address.com/v2/aggregate"))
 	})
 
-	It("returns legacy aggregate drains from the cache", func() {
-		bindings := []binding.LegacyBinding{
-			{
-				AppID:    "app-id-1",
-				Drains:   []string{"drain-1"},
-				Hostname: "host-1",
-			},
-		}
-
-		j, err := json.Marshal(bindings)
-		Expect(err).ToNot(HaveOccurred())
-		spyHTTPClient.response = &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader(j)),
-		}
-
-		Expect(client.GetLegacyAggregate()).To(Equal(bindings))
-		Expect(spyHTTPClient.requestURL).To(Equal("https://cache.address.com/aggregate"))
-	})
-
 	It("returns empty bindings if an HTTP error occurs", func() {
 		spyHTTPClient.err = errors.New("http error")
 
@@ -125,18 +84,6 @@ var _ = Describe("Client", func() {
 		Expect(err).To(MatchError("http error"))
 
 		_, err = client.GetAggregate()
-
-		Expect(err).To(MatchError("http error"))
-	})
-
-	It("returns empty legacy bindings if an HTTP error occurs", func() {
-		spyHTTPClient.err = errors.New("http error")
-
-		_, err := client.Get()
-
-		Expect(err).To(MatchError("http error"))
-
-		_, err = client.GetLegacyAggregate()
 
 		Expect(err).To(MatchError("http error"))
 	})
@@ -155,21 +102,6 @@ var _ = Describe("Client", func() {
 
 		Expect(err).To(MatchError("unexpected http response from binding cache: 500"))
 	})
-
-	It("returns empty legacy bindings if cache returns a non-OK status code", func() {
-		spyHTTPClient.response = &http.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       io.NopCloser(strings.NewReader("")),
-		}
-
-		_, err := client.Get()
-
-		Expect(err).To(MatchError("unexpected http response from binding cache: 500"))
-
-		_, err = client.GetLegacyAggregate()
-
-		Expect(err).To(MatchError("unexpected http response from binding cache: 500"))
-	})
 })
 
 type spyHTTPClient struct {
@@ -183,11 +115,6 @@ func newSpyHTTPClient() *spyHTTPClient {
 }
 
 func (s *spyHTTPClient) Get(url string) (*http.Response, error) {
-	s.requestURL = url
-	return s.response, s.err
-}
-
-func (s *spyHTTPClient) LegacyGet(url string) (*http.Response, error) {
 	s.requestURL = url
 	return s.response, s.err
 }

--- a/src/pkg/cache/handler.go
+++ b/src/pkg/cache/handler.go
@@ -12,13 +12,8 @@ type Getter interface {
 	Get() []binding.Binding
 }
 
-type LegacyGetter interface {
-	Get() []binding.LegacyBinding
-}
-
 type AggregateGetter interface {
 	Get() []binding.Binding
-	LegacyGet() []binding.LegacyBinding
 }
 
 func Handler(store Getter) http.HandlerFunc {
@@ -31,29 +26,9 @@ func Handler(store Getter) http.HandlerFunc {
 	}
 }
 
-func LegacyHandler(store LegacyGetter) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		err := json.NewEncoder(w).Encode(store.Get())
-		if err != nil {
-			log.Printf("failed to encode response body: %s", err)
-			return
-		}
-	}
-}
-
 func AggregateHandler(store AggregateGetter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := json.NewEncoder(w).Encode(store.Get())
-		if err != nil {
-			log.Printf("failed to encode response body: %s", err)
-			return
-		}
-	}
-}
-
-func LegacyAggregateHandler(store AggregateGetter) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		err := json.NewEncoder(w).Encode(store.LegacyGet())
 		if err != nil {
 			log.Printf("failed to encode response body: %s", err)
 			return

--- a/src/pkg/ingress/api/client.go
+++ b/src/pkg/ingress/api/client.go
@@ -6,8 +6,7 @@ import (
 )
 
 var (
-	legacyPathTemplate = "%s/internal/v4/syslog_drain_urls?batch_size=%d&next_id=%d"
-	pathTemplate       = "%s/internal/v5/syslog_drain_urls?batch_size=%d&next_id=%d"
+	pathTemplate = "%s/internal/v5/syslog_drain_urls?batch_size=%d&next_id=%d"
 )
 
 type Client struct {
@@ -18,8 +17,4 @@ type Client struct {
 
 func (w Client) Get(nextID int) (*http.Response, error) {
 	return w.Client.Get(fmt.Sprintf(pathTemplate, w.Addr, w.BatchSize, nextID))
-}
-
-func (w Client) LegacyGet(nextID int) (*http.Response, error) {
-	return w.Client.Get(fmt.Sprintf(legacyPathTemplate, w.Addr, w.BatchSize, nextID))
 }


### PR DESCRIPTION
# Description

With the introduction of mTLS for Syslog Drains we have changed the internal structure of the bindings. In order to enable updating without downtime of the cloud controller, the syslog binding cache and the syslog agent, we have introduced two endpoints for reading the syslog binding in the old and new format. This PR cleans up the code of the legacy syslog bindings and removes the http calls to the old Syslog Binding Cache API endpoint. From now on, only the `/v2/binding` and `/v2/aggregate-bindings` API endpoints of the Syslog Binding Cache will be used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

This PR should be merged after merging the changes introduced with the [this PR](https://github.com/cloudfoundry/cloud_controller_ng/pull/3527) in the Cloud Controller 
