### PR TITLE
Remove __v1_type tag when forwarding metrics to otel collector

### DIFF
--- a/src/pkg/otelcolclient/otelcolclient.go
+++ b/src/pkg/otelcolclient/otelcolclient.go
@@ -173,7 +173,7 @@ func attributes(e *loggregator_v2.Envelope) []*commonpb.KeyValue {
 	}
 
 	for k, v := range e.Tags {
-		if k == "instance_id" || k == "source_id" {
+		if k == "instance_id" || k == "source_id" || k == "__v1_type" {
 			continue
 		}
 

--- a/src/pkg/otelcolclient/otelcolclient_test.go
+++ b/src/pkg/otelcolclient/otelcolclient_test.go
@@ -255,6 +255,20 @@ var _ = Describe("Client", func() {
 					Expect(cmp.Diff(actualAtts, expectedAtts, protocmp.Transform(), sortFunc)).To(BeEmpty())
 				})
 			})
+
+			Context("when the envelope has been converted from a v1 representation", func() {
+				BeforeEach(func() {
+					envelope.Tags["__v1_type"] = "ValueMetric"
+				})
+
+				It("drops the __v1_type tag", func() {
+					var msr *colmetricspb.ExportMetricsServiceRequest
+					Expect(spyMSC.requests).To(Receive(&msr))
+
+					actualAtts := msr.GetResourceMetrics()[0].GetScopeMetrics()[0].GetMetrics()[0].GetGauge().GetDataPoints()[0].GetAttributes()
+					Expect(actualAtts).ToNot(ContainElement(HaveField("Key", "__v1_type")))
+				})
+			})
 		})
 
 		Context("when given a counter", func() {


### PR DESCRIPTION
# Description

- Metrics that were received initially as v1 metrics include a __v1_type tag to indicate the type of v1 metric that was emitted.
- This causes issues for the prometheus exporter as: 'Label names beginning with __ (two "_") are reserved for internal use.' https://prometheus.io/docs/concepts/data_model/
- Remove the __v1_type tag during the conversion so that these metrics will be acceptable to prometheus exporters.

Fixes:
```
 "__v1_type" is not a valid label name for metric
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
