### PR TITLE
Specify that counters are monotonic

### DIFF
--- a/src/pkg/otelcolclient/otelcolclient.go
+++ b/src/pkg/otelcolclient/otelcolclient.go
@@ -113,6 +113,7 @@ func (c *Client) addCounterToBatch(e *loggregator_v2.Envelope) {
 		Data: &metricspb.Metric_Sum{
 			Sum: &metricspb.Sum{
 				AggregationTemporality: metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				IsMonotonic:            true,
 				DataPoints: []*metricspb.NumberDataPoint{
 					{
 						TimeUnixNano: uint64(e.GetTimestamp()),

--- a/src/pkg/otelcolclient/otelcolclient.go
+++ b/src/pkg/otelcolclient/otelcolclient.go
@@ -113,7 +113,7 @@ func (c *Client) addCounterToBatch(e *loggregator_v2.Envelope) {
 		Data: &metricspb.Metric_Sum{
 			Sum: &metricspb.Sum{
 				AggregationTemporality: metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
-				IsMonotonic:            true,
+				IsMonotonic:            e.GetCounter().GetDelta() == 0,
 				DataPoints: []*metricspb.NumberDataPoint{
 					{
 						TimeUnixNano: uint64(e.GetTimestamp()),

--- a/src/pkg/otelcolclient/otelcolclient_test.go
+++ b/src/pkg/otelcolclient/otelcolclient_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Client", func() {
 											Data: &metricspb.Metric_Sum{
 												Sum: &metricspb.Sum{
 													AggregationTemporality: metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
-													IsMonotonic:            false,
+													IsMonotonic:            true,
 													DataPoints: []*metricspb.NumberDataPoint{
 														{
 															TimeUnixNano: 1257894000000000000,


### PR DESCRIPTION
# Description

Sums must be declared as monotonic in order to be represented in prometheus as counters.

Note that this causes the otel collector to rename metrics when using the prometheus exporter. Counters have `_total` appended to the name.

There are cases where loggregator counters aren't monotonic, in particular when counters are emitted only as deltas (V1) and the counter totals are reset in the Forwarder Agent. In this case we mark the otel sum as not monotonic and it will be represented as a gauge when using the prometheus exporter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
