### PR TITLE
Don't register loggregator agent when not enabled

### DIFF
--- a/jobs/loggregator_agent/templates/pre-start.erb
+++ b/jobs/loggregator_agent/templates/pre-start.erb
@@ -6,7 +6,7 @@ if_link("doppler") do |d|
 end
 %>
 
-<% unless has_doppler %>
+<% if ! p('enabled') || ! has_doppler %>
 rm /var/vcap/jobs/loggregator_agent/config/ingress_port.yml
 rm /var/vcap/jobs/loggregator_agent/config/prom_scraper_config.yml
 <% end %>

--- a/jobs/loggregator_agent_windows/templates/pre-start.ps1.erb
+++ b/jobs/loggregator_agent_windows/templates/pre-start.ps1.erb
@@ -7,7 +7,7 @@ end
 New-Item -Path /var/vcap/sys/run/loggregator_agent_windows -ItemType directory -Force
 New-Item -Path /var/vcap/sys/log/loggregator_agent_windows -ItemType directory -Force
 
-<%unless has_doppler%>
+<% if ! p('enabled') || ! has_doppler %>
 Remove-Item -Path /var/vcap/jobs/loggregator_agent_windows/config/ingress_port.yml
 Remove-Item -Path /var/vcap/jobs/loggregator_agent_windows/config/prom_scraper_config.yml
-<%end%>
+<% end %>


### PR DESCRIPTION
# Description

Don't register loggregator agent with forwarder agent or prom scraper when the loggregator agent is not enabled.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Manual testing

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
