### PR TITLE
Bump to go1.21

### DIFF
--- a/packages/binding-cache/packaging
+++ b/packages/binding-cache/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/binding-cache ./cmd/syslog-binding-cache

--- a/packages/binding-cache/spec
+++ b/packages/binding-cache/spec
@@ -2,7 +2,7 @@
 name: binding-cache
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 files:
 - cmd/syslog-binding-cache/**/*.go
 - pkg/**/*.go

--- a/packages/forwarder-agent-windows/packaging
+++ b/packages/forwarder-agent-windows/packaging
@@ -1,5 +1,5 @@
 . ./exiter.ps1
-. C:\var\vcap\packages\golang-1.20-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-1.21-windows\bosh\compile.ps1
 $env:GOPATH="C:\var\vcap"
 
 $ErrorActionPreference = "Stop";

--- a/packages/forwarder-agent-windows/spec
+++ b/packages/forwarder-agent-windows/spec
@@ -2,7 +2,7 @@
 name: forwarder-agent-windows
 
 dependencies:
-- golang-1.20-windows
+- golang-1.21-windows
 
 files:
 - exiter.ps1

--- a/packages/forwarder-agent/packaging
+++ b/packages/forwarder-agent/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/forwarder-agent ./cmd/forwarder-agent

--- a/packages/forwarder-agent/spec
+++ b/packages/forwarder-agent/spec
@@ -2,7 +2,7 @@
 name: forwarder-agent
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 files:
 - cmd/forwarder-agent/**/*.go
 - pkg/**/*.go

--- a/packages/golang-1.20-linux/spec.lock
+++ b/packages/golang-1.20-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.20-linux
-fingerprint: 8859f2c2f47d9b58d85ae101405d8af92c7d26d30231721341bc49bd657ccb4d

--- a/packages/golang-1.20-windows/spec.lock
+++ b/packages/golang-1.20-windows/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.20-windows
-fingerprint: 81659ca824a3b5d8adb2974f48aea88b815e14d50c3099acd960853bcd485dda

--- a/packages/loggregator_agent/packaging
+++ b/packages/loggregator_agent/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/loggregator-agent ./cmd/loggregator-agent

--- a/packages/loggregator_agent/spec
+++ b/packages/loggregator_agent/spec
@@ -2,7 +2,7 @@
 name: loggregator_agent
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 files:
 - cmd/loggregator-agent/**/*.go
 - pkg/**/*.go

--- a/packages/loggregator_agent_windows/packaging
+++ b/packages/loggregator_agent_windows/packaging
@@ -1,5 +1,5 @@
 . ./exiter.ps1
-. C:\var\vcap\packages\golang-1.20-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-1.21-windows\bosh\compile.ps1
 $env:GOPATH="C:\var\vcap"
 
 $ErrorActionPreference = "Stop";

--- a/packages/loggregator_agent_windows/spec
+++ b/packages/loggregator_agent_windows/spec
@@ -2,7 +2,7 @@
 name: loggregator_agent_windows
 
 dependencies:
-- golang-1.20-windows
+- golang-1.21-windows
 
 files:
 - exiter.ps1

--- a/packages/prom_scraper/packaging
+++ b/packages/prom_scraper/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/prom-scraper ./cmd/prom-scraper

--- a/packages/prom_scraper/spec
+++ b/packages/prom_scraper/spec
@@ -2,7 +2,7 @@
 name: prom_scraper
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 files:
 - cmd/prom-scraper/**/*.go
 - cmd/prom-scraper/get-metrics.sh

--- a/packages/prom_scraper_windows/packaging
+++ b/packages/prom_scraper_windows/packaging
@@ -1,5 +1,5 @@
 . ./exiter.ps1
-. C:\var\vcap\packages\golang-1.20-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-1.21-windows\bosh\compile.ps1
 $env:GOPATH="C:\var\vcap"
 
 $ErrorActionPreference = "Stop";

--- a/packages/prom_scraper_windows/spec
+++ b/packages/prom_scraper_windows/spec
@@ -2,7 +2,7 @@
 name: prom_scraper_windows
 
 dependencies:
-- golang-1.20-windows
+- golang-1.21-windows
 
 files:
 - exiter.ps1

--- a/packages/syslog-agent-windows/packaging
+++ b/packages/syslog-agent-windows/packaging
@@ -1,5 +1,5 @@
 . ./exiter.ps1
-. C:\var\vcap\packages\golang-1.20-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-1.21-windows\bosh\compile.ps1
 $env:GOPATH="C:\var\vcap"
 
 $ErrorActionPreference = "Stop";

--- a/packages/syslog-agent-windows/spec
+++ b/packages/syslog-agent-windows/spec
@@ -2,7 +2,7 @@
 name: syslog-agent-windows
 
 dependencies:
-- golang-1.20-windows
+- golang-1.21-windows
 
 files:
 - exiter.ps1

--- a/packages/syslog-agent/packaging
+++ b/packages/syslog-agent/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/syslog-agent ./cmd/syslog-agent

--- a/packages/syslog-agent/spec
+++ b/packages/syslog-agent/spec
@@ -2,7 +2,7 @@
 name: syslog-agent
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 files:
 - cmd/syslog-agent/**/*.go
 - pkg/**/*.go

--- a/packages/udp-forwarder/packaging
+++ b/packages/udp-forwarder/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.20-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/udp-forwarder ./cmd/udp-forwarder

--- a/packages/udp-forwarder/spec
+++ b/packages/udp-forwarder/spec
@@ -2,7 +2,7 @@
 name: udp-forwarder
 
 dependencies:
-- golang-1.20-linux
+- golang-1.21-linux
 files:
 - cmd/udp-forwarder/**/*.go
 - pkg/**/*.go

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/loggregator-agent-release/src
 
-go 1.20
+go 1.21
 
 require (
 	code.cloudfoundry.org/go-batching v0.0.0-20171020220229-924d2a9b48ac

--- a/src/go.sum
+++ b/src/go.sum
@@ -102,6 +102,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -118,9 +119,12 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nelsam/hel/v2 v2.3.2/go.mod h1:1ZTGfU2PFTOd5mx22i5O0Lc2GY933lQ2wb/ggy+rL3w=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY=
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
@@ -151,6 +155,7 @@ github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3c
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -217,6 +222,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -263,8 +269,10 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
# Description

* Removes go1.20 packages
* Uses go1.21 packages to build the other packages
* Specify go1.21 as the go version in `src/go.mod`

## Type of change

- [x] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
