### PR TITLE
Fix typo in specification of job `loggr-syslog-binding-cache`

### DIFF
--- a/jobs/loggr-syslog-binding-cache/spec
+++ b/jobs/loggr-syslog-binding-cache/spec
@@ -64,7 +64,7 @@ properties:
   tls.cert:
     description: "TLS certificate for binding-cache signed by the loggregator CA"
   tls.key:
-    description: "TLS private key for binfing-cache signed by the loggregator CA"
+    description: "TLS private key for binding-cache signed by the loggregator CA"
   tls.cn:
     description: "The common name the cache will use to validate certs"
   tls.cipher_suites:


### PR DESCRIPTION
This PR fixes just a very simple typo in the job specification of `loggr-syslog-binding-cache`.