### PR TITLE
fix: Failing scripts/unit-test action

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: "src/go.mod"
+          go-version: '1.21'
+          check-latest: true
       - run: ./scripts/subtests/unit-test
 
   lint:
@@ -26,5 +27,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: "src/go.mod"
+          go-version: '1.21'
+          check-latest: true
       - run: ./scripts/subtests/lint


### PR DESCRIPTION
Fixes failing scripts/unit-test GH action by using the latest patch of go1.21 instead of go1.21.0.

We were seeing errors like:

```
Failed to compile otel-collector:
...
compile: version "go1.21.9" does not match go tool version "go1.21.0"
```
