### PR TITLE
fix(syslog-binding-cache): Wait for the entire polling interval

### DIFF
--- a/src/pkg/binding/poller.go
+++ b/src/pkg/binding/poller.go
@@ -71,10 +71,9 @@ func NewPoller(ac client, pi time.Duration, s Setter, m Metrics, logger *log.Log
 }
 
 func (p *Poller) Poll() {
-	t := time.NewTicker(p.pollingInterval)
-
-	for range t.C {
+	for {
 		p.poll()
+		time.Sleep(p.pollingInterval)
 	}
 }
 


### PR DESCRIPTION
Fixes syslog-binding-cache to wait for the polling interval AFTER it has finished polling, rather than incorporating the polling time into the polling interval.
