### PR TITLE
Address linting and fix unit test flakiness

### DIFF
--- a/src/cmd/syslog-agent/app/config.go
+++ b/src/cmd/syslog-agent/app/config.go
@@ -140,8 +140,7 @@ func convertCipherStringToInt(cipherStrs []string, cipherMap map[string]uint16) 
 			for key := range cipherMap {
 				supportedCipherSuites = append(supportedCipherSuites, key)
 			}
-			errMsg := fmt.Sprintf("Invalid cipher string configuration: %s, please choose from %v", cipher, supportedCipherSuites)
-			return nil, fmt.Errorf(errMsg)
+			return nil, fmt.Errorf("Invalid cipher string configuration: %s, please choose from %v", cipher, supportedCipherSuites)
 		}
 	}
 

--- a/src/pkg/binding/poller_test.go
+++ b/src/pkg/binding/poller_test.go
@@ -391,7 +391,7 @@ var _ = Describe("Poller", func() {
 			V5Available: true,
 		}
 
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
+		p := binding.NewPoller(apiClient, 100*time.Millisecond, store, legacyStore, metrics, logger)
 		go p.Poll()
 
 		Eventually(store.bindings).Should(BeEmpty())
@@ -402,7 +402,7 @@ var _ = Describe("Poller", func() {
 		apiClient.statusCode <- 404
 		apiClient.legacyStatusCode <- 404
 
-		p := binding.NewPoller(apiClient, 10*time.Millisecond, store, legacyStore, metrics, logger)
+		p := binding.NewPoller(apiClient, 100*time.Millisecond, store, legacyStore, metrics, logger)
 		go p.Poll()
 
 		Eventually(store.bindings).Should(BeEmpty())


### PR DESCRIPTION
# Description

Address lint error and test flakiness in `PollerTest` by increasing polling interval to `100ms` to fix failing `bump-dependencies` job. Increasing the interval ensures `Poll()`  runs less frequently giving the test more time to perform the assertions before the channel is updated.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
