### PR TITLE
fix uint to int conversion for otlp

### DIFF
--- a/src/pkg/otelcolclient/otelcolclient.go
+++ b/src/pkg/otelcolclient/otelcolclient.go
@@ -242,7 +242,7 @@ func (c *Client) writeCounter(e *loggregator_v2.Envelope) {
 						TimeUnixNano: uint64(e.GetTimestamp()),
 						Attributes:   atts,
 						Value: &metricspb.NumberDataPoint_AsInt{
-							AsInt: int64(e.GetCounter().GetTotal()), //#nosec G115
+							AsInt: int64(e.GetCounter().GetTotal() << 1 >> 1), //#nosec G115
 						},
 					},
 				},


### PR DESCRIPTION
Prevents ints from overflowing when being sent over otlp, as loggregator ints are unsigned and otel ints are signed. Since counters are expected to roll over we just discard the highest order bit.

# Description

Please include a summary of the change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
