### PR TITLE
Emit all OTel signals by default

### DIFF
--- a/jobs/loggr-forwarder-agent/spec
+++ b/jobs/loggr-forwarder-agent/spec
@@ -35,16 +35,16 @@ properties:
     example: {"deployment": "cf"}
 
   emit_otel_traces:
-    description: "Whether to emit traces to OpenTelemetry Collector downstream consumers"
-    default: false
+    description: "Emit traces to downstream OpenTelemetry consumers"
+    default: true
 
   emit_otel_metrics:
-    description: "Whether to emit metrics to OpenTelemetry Collector downstream consumers"
+    description: "Emit metrics to downstream OpenTelemetry consumers"
     default: true
 
   emit_otel_logs:
-    description: "Whether to emit logs to OpenTelemetry Collector downstream consumers"
-    default: false
+    description: "Emit logs to downstream OpenTelemetry consumers"
+    default: true
 
   tls.ca_cert:
     description: |

--- a/src/pkg/otelcolclient/otelcolclient.go
+++ b/src/pkg/otelcolclient/otelcolclient.go
@@ -170,9 +170,9 @@ func (c *Client) writeLog(e *loggregator_v2.Envelope) {
 			{
 				LogRecords: []*logspb.LogRecord{
 					{
-						TimeUnixNano:         uint64(e.GetTimestamp()),
+						TimeUnixNano:         uint64(e.GetTimestamp()), // nolint:gosec
 						Attributes:           atts,
-						ObservedTimeUnixNano: uint64(time.Now().UnixNano()),
+						ObservedTimeUnixNano: uint64(time.Now().UnixNano()), // nolint:gosec
 						SeverityText:         svrtyNumber.String(),
 						SeverityNumber:       svrtyNumber,
 						Body: &commonpb.AnyValue{
@@ -199,9 +199,9 @@ func (c *Client) writeEvent(e *loggregator_v2.Envelope) {
 			{
 				LogRecords: []*logspb.LogRecord{
 					{
-						TimeUnixNano:         uint64(e.GetTimestamp()),
+						TimeUnixNano:         uint64(e.GetTimestamp()), // nolint:gosec
 						Attributes:           atts,
-						ObservedTimeUnixNano: uint64(time.Now().UnixNano()),
+						ObservedTimeUnixNano: uint64(time.Now().UnixNano()), // nolint:gosec
 						Body: &commonpb.AnyValue{
 							Value: &commonpb.AnyValue_KvlistValue{
 								KvlistValue: &commonpb.KeyValueList{
@@ -239,7 +239,7 @@ func (c *Client) writeCounter(e *loggregator_v2.Envelope) {
 				IsMonotonic:            e.GetCounter().GetDelta() == 0,
 				DataPoints: []*metricspb.NumberDataPoint{
 					{
-						TimeUnixNano: uint64(e.GetTimestamp()),
+						TimeUnixNano: uint64(e.GetTimestamp()), // nolint:gosec
 						Attributes:   atts,
 						Value: &metricspb.NumberDataPoint_AsInt{
 							AsInt: int64(e.GetCounter().GetTotal() << 1 >> 1), //#nosec G115
@@ -266,7 +266,7 @@ func (c *Client) writeGauge(e *loggregator_v2.Envelope) {
 				Gauge: &metricspb.Gauge{
 					DataPoints: []*metricspb.NumberDataPoint{
 						{
-							TimeUnixNano: uint64(e.GetTimestamp()),
+							TimeUnixNano: uint64(e.GetTimestamp()), // nolint:gosec
 							Attributes:   atts,
 							Value: &metricspb.NumberDataPoint_AsDouble{
 								AsDouble: v.GetValue(),
@@ -320,8 +320,8 @@ func (c *Client) writeTimer(e *loggregator_v2.Envelope) {
 						SpanId:            spanId,
 						Name:              name,
 						Kind:              kind,
-						StartTimeUnixNano: uint64(e.GetTimer().GetStart()),
-						EndTimeUnixNano:   uint64(e.GetTimer().GetStop()),
+						StartTimeUnixNano: uint64(e.GetTimer().GetStart()), // nolint:gosec
+						EndTimeUnixNano:   uint64(e.GetTimer().GetStop()),  // nolint:gosec
 						Status: &tracepb.Status{
 							Code: tracepb.Status_STATUS_CODE_UNSET,
 						},


### PR DESCRIPTION
# Description

The OpenTelemetry Collector release now sets up noop pipelines to consume these signals and prevent error messages if no pipelines for the signal have been configured by the operator.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
