### PR TITLE
fix: windows emits otel signals by default

### DIFF
--- a/jobs/loggr-forwarder-agent-windows/spec
+++ b/jobs/loggr-forwarder-agent-windows/spec
@@ -35,16 +35,16 @@ properties:
     example: {"deployment": "cf"}
 
   emit_otel_traces:
-    description: "Whether to emit traces to OpenTelemetry Collector downstream consumers"
-    default: false
+    description: "Emit traces to downstream OpenTelemetry consumers"
+    default: true
 
   emit_otel_metrics:
-    description: "Whether to emit metrics to OpenTelemetry Collector downstream consumers"
+    description: "Emit metrics to downstream OpenTelemetry consumers"
     default: true
 
   emit_otel_logs:
-    description: "Whether to emit logs to OpenTelemetry Collector downstream consumers"
-    default: false
+    description: "Emit logs to downstream OpenTelemetry consumers"
+    default: true
 
   tls.ca_cert:
     description: |


### PR DESCRIPTION
# Description

Fixes feef623ec to also add Windows support for emitting all otel signals by default.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
