### PR TITLE
Retry refactor to allow for batching to retry.

### DIFF
--- a/src/pkg/egress/syslog/https.go
+++ b/src/pkg/egress/syslog/https.go
@@ -43,7 +43,7 @@ func NewHTTPSWriter(
 	}
 }
 
-func (w *HTTPSWriter) sendHttpRequest(msg []byte, msgCount float64) error {
+func (w *HTTPSWriter) sendHttpRequest(msg []byte) error {
 	req := fasthttp.AcquireRequest()
 	req.SetRequestURI(w.url.String())
 	req.Header.SetMethod("POST")
@@ -63,8 +63,6 @@ func (w *HTTPSWriter) sendHttpRequest(msg []byte, msgCount float64) error {
 		return fmt.Errorf("syslog Writer: Post responded with %d status code", resp.StatusCode())
 	}
 
-	w.egressMetric.Add(msgCount)
-
 	return nil
 }
 
@@ -76,10 +74,11 @@ func (w *HTTPSWriter) Write(env *loggregator_v2.Envelope) error {
 	}
 
 	for _, msg := range msgs {
-		err = w.sendHttpRequest(msg, 1)
+		err = w.sendHttpRequest(msg)
 		if err != nil {
 			return err
 		}
+		w.egressMetric.Add(1)
 	}
 
 	return nil

--- a/src/pkg/egress/syslog/https_batch_test.go
+++ b/src/pkg/egress/syslog/https_batch_test.go
@@ -39,12 +39,18 @@ var _ = Describe("HTTPS_batch", func() {
 			"test-app-id",
 			"test-hostname",
 		)
+		retryer := syslog.NewBackoffRetryer(
+			b,
+			syslog.ExponentialDuration,
+			2,
+		)
 		writer = syslog.NewHTTPSBatchWriter(
 			b,
 			netConf,
 			skipSSLTLSConfig,
 			&metricsHelpers.SpyMetric{},
 			c,
+			retryer,
 		)
 	})
 

--- a/src/pkg/egress/syslog/retryer.go
+++ b/src/pkg/egress/syslog/retryer.go
@@ -1,0 +1,52 @@
+package syslog
+
+import (
+	"log"
+	"time"
+
+	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress"
+)
+
+// RetryWriter wraps a WriteCloser and will retry writes if the first fails.
+type Retryer struct {
+	retryDuration RetryDuration
+	maxRetries    int
+	binding       *URLBinding
+}
+
+func NewBackoffRetryer(
+	urlBinding *URLBinding,
+	retryDuration RetryDuration,
+	maxRetries int,
+) *Retryer {
+	return &Retryer{
+		retryDuration: retryDuration,
+		maxRetries:    maxRetries,
+		binding:       urlBinding,
+	}
+}
+
+// Write will retry writes unitl maxRetries has been reached.
+func (r *Retryer) Retry(message []byte, fn func(msg []byte) error) error {
+	logTemplate := "failed to write to %s, retrying in %s, err: %s"
+
+	var err error
+
+	for i := 0; i < r.maxRetries; i++ {
+		err = fn(message)
+		if err == nil {
+			return nil
+		}
+
+		if egress.ContextDone(r.binding.Context) {
+			return err
+		}
+
+		sleepDuration := r.retryDuration(i)
+		log.Printf(logTemplate, r.binding.URL.Host, sleepDuration, err)
+
+		time.Sleep(sleepDuration)
+	}
+
+	return err
+}

--- a/src/pkg/egress/syslog/writer_factory.go
+++ b/src/pkg/egress/syslog/writer_factory.go
@@ -96,6 +96,11 @@ func (f WriterFactory) NewWriter(ub *URLBinding) (egress.WriteCloser, error) {
 	}
 	converter := NewConverter(o...)
 
+	retryer := NewBackoffRetryer(
+		ub,
+		ExponentialDuration,
+		maxRetries)
+
 	var w egress.WriteCloser
 	switch ub.URL.Scheme {
 	case "https":
@@ -113,6 +118,7 @@ func (f WriterFactory) NewWriter(ub *URLBinding) (egress.WriteCloser, error) {
 			tlsCfg,
 			egressMetric,
 			converter,
+			retryer,
 		)
 	case "syslog":
 		w = NewTCPWriter(


### PR DESCRIPTION
# Description

This change mostly  changes around, where the retry logic is applied.
Thinking about the things that need to be retried, this is likely to only be needed for networking.
So the logic of retrying should be done after the serialisation of the data for every protocol, to increase performance and locality of problem solutions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
