### PR TITLE
disable parallel unit tests in CI

### DIFF
--- a/scripts/subtests/unit-test
+++ b/scripts/subtests/unit-test
@@ -5,7 +5,11 @@ set -o pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
+flags='-r --randomize-all --randomize-suites --fail-on-pending --keep-going --race --trace'
+if [ "${CI:-false}" = 'true' ]; then
+    flags="${flags} -p"
+fi
 pushd "${SCRIPT_DIR}/../../src" > /dev/null
-    go run github.com/onsi/ginkgo/v2/ginkgo -r -p --randomize-all --randomize-suites --fail-on-pending --keep-going --race --trace
+    go run github.com/onsi/ginkgo/v2/ginkgo $flags 
 popd > /dev/null
 


### PR DESCRIPTION
cherry-picked from 9d1236930563dd5d3e2b01ac4513a295eedacc81

# Description
Cherry pick test parallelism config from main.

## Type of change
- CI chore

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch - v7.x
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes
