### PR TITLE
Fix https_batch deadlock due to golang timer changes

### DIFF
--- a/src/pkg/egress/syslog/https_batch.go
+++ b/src/pkg/egress/syslog/https_batch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"log"
+	"sync"
 	"time"
 
 	"code.cloudfoundry.org/go-loggregator/v10/rpc/loggregator_v2"
@@ -11,14 +12,27 @@ import (
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress"
 )
 
-const BATCHSIZE = 256 * 1024
-
 type HTTPSBatchWriter struct {
 	HTTPSWriter
-	msgs         chan []byte
 	batchSize    int
 	sendInterval time.Duration
-	egrMsgCount  float64
+	msgChan      chan []byte
+	quit         chan struct{}
+	wg           sync.WaitGroup
+}
+
+type Option func(*HTTPSBatchWriter)
+
+func WithBatchSize(size int) Option {
+	return func(w *HTTPSBatchWriter) {
+		w.batchSize = size
+	}
+}
+
+func WithSendInterval(interval time.Duration) Option {
+	return func(w *HTTPSBatchWriter) {
+		w.sendInterval = interval
+	}
 }
 
 func NewHTTPSBatchWriter(
@@ -27,10 +41,12 @@ func NewHTTPSBatchWriter(
 	tlsConf *tls.Config,
 	egressMetric metrics.Counter,
 	c *Converter,
+	options ...Option,
 ) egress.WriteCloser {
 	client := httpClient(netConf, tlsConf)
-	binding.URL.Scheme = "https" // reset the scheme for usage to a valid http scheme
-	BatchWriter := &HTTPSBatchWriter{
+	binding.URL.Scheme = "https"
+
+	writer := &HTTPSBatchWriter{
 		HTTPSWriter: HTTPSWriter{
 			url:             binding.URL,
 			appID:           binding.AppID,
@@ -39,60 +55,79 @@ func NewHTTPSBatchWriter(
 			egressMetric:    egressMetric,
 			syslogConverter: c,
 		},
-		batchSize:    BATCHSIZE,
-		sendInterval: 1 * time.Second,
-		egrMsgCount:  0,
-		msgs:         make(chan []byte),
+		batchSize:    256 * 1024,        // Default value
+		sendInterval: 1 * time.Second,   // Default value
+		msgChan:      make(chan []byte), // Buffered channel for messages
+		quit:         make(chan struct{}),
 	}
-	go BatchWriter.startSender()
-	return BatchWriter
+
+	for _, opt := range options {
+		opt(writer)
+	}
+
+	writer.wg.Add(1)
+	go writer.startSender()
+
+	return writer
 }
 
-// Modified Write function
 func (w *HTTPSBatchWriter) Write(env *loggregator_v2.Envelope) error {
 	msgs, err := w.syslogConverter.ToRFC5424(env, w.hostname)
 	if err != nil {
-		log.Printf("Failed to parse syslog, dropping faulty message, err: %s", err)
+		log.Printf("Failed to parse syslog, dropping message, err: %s", err)
 		return nil
 	}
 
 	for _, msg := range msgs {
-		//There is no correct way of implementing error based retries in the current architecture.
-		//Retries for https-batching will be implemented at a later point in time.
-		w.msgs <- msg
+		w.msgChan <- msg
 	}
+
 	return nil
 }
 
 func (w *HTTPSBatchWriter) startSender() {
-	t := time.NewTimer(w.sendInterval)
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.sendInterval)
+	defer ticker.Stop()
 
 	var msgBatch bytes.Buffer
 	var msgCount float64
-	reset := func() {
-		msgBatch.Reset()
-		msgCount = 0
-		t.Reset(w.sendInterval)
-	}
-	for {
-		select {
-		case msg := <-w.msgs:
-			length, buffer_err := msgBatch.Write(msg)
-			if buffer_err != nil {
-				log.Printf("Failed to write to buffer, dropping buffer of size %d , err: %s", length, buffer_err)
-				reset()
-			} else {
-				msgCount++
-				if length >= w.batchSize {
-					w.sendHttpRequest(msgBatch.Bytes(), msgCount) //nolint:errcheck
-					reset()
-				}
-			}
-		case <-t.C:
-			if msgBatch.Len() > 0 {
-				w.sendHttpRequest(msgBatch.Bytes(), msgCount) //nolint:errcheck
-				reset()
-			}
+
+	sendBatch := func() {
+		if msgBatch.Len() > 0 {
+			w.sendHttpRequest(msgBatch.Bytes(), msgCount) // nolint:errcheck
+			msgBatch.Reset()
+			msgCount = 0
 		}
 	}
+
+	for {
+		select {
+		case msg := <-w.msgChan:
+			_, err := msgBatch.Write(msg)
+			if err != nil {
+				log.Printf("Failed to write to buffer, dropping buffer of size %d , err: %s", msgBatch.Len(), err)
+				msgBatch.Reset()
+				msgCount = 0
+			} else {
+				msgCount++
+				if msgBatch.Len() >= w.batchSize {
+					sendBatch()
+				}
+			}
+		case <-ticker.C:
+			sendBatch()
+		case <-w.quit:
+			sendBatch()
+			return
+		}
+	}
+}
+
+func (w *HTTPSBatchWriter) Close() error {
+	close(w.quit)
+	w.wg.Wait() // Ensure sender finishes processing before closing
+	close(w.msgChan)
+	return nil
 }

--- a/src/pkg/egress/syslog/https_test.go
+++ b/src/pkg/egress/syslog/https_test.go
@@ -247,8 +247,15 @@ var _ = Describe("HTTPWriter", func() {
 type SpyDrain struct {
 	mu sync.Mutex
 	*httptest.Server
-	messages []*rfc5424.Message
-	headers  []http.Header
+	messages     []*rfc5424.Message
+	headers      []http.Header
+	requestCount int
+}
+
+func (d *SpyDrain) Reset() {
+	d.messages = nil
+	d.headers = nil
+	d.requestCount = 0
 }
 
 func (d *SpyDrain) appendMessage(message *rfc5424.Message) {
@@ -269,6 +276,9 @@ func (d *SpyDrain) getMessagesSize() int {
 	return len(d.messages)
 }
 
+func (d *SpyDrain) getRequestCount() int {
+	return d.requestCount
+}
 func newMockOKDrain() *SpyDrain {
 	return newMockDrain(http.StatusOK)
 }


### PR DESCRIPTION
### What is changed:

This changes the way the syslog batches are triggered.
The new implementation no longer uses Timers that need to be reset and checked, it just ticks once every second per http_batch drain to send a batch at least once a second. 
The new logic is as follows:
- If there is a log present in the queue, send it at last one second later with every log from the same second.
- If there are more logs in one second than the 'batchSize' allows, send the batch immediately 

### The problem fixed by this change:

The old implementation was able to deadlock itself due to the way the time channel was reset. There are even more changes to this behaviour to be expected by the golang 1.23 update. (https://tip.golang.org/doc/go1.23#timer-changes)
-> Changed logic necessary to prevent further issues on further golang upgrades

### Impact:
The new implementation will tick more often, but the overhead will be pretty minimal, due to not doing anything for empty drains.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing performed?

- [x] Unit tests
- [x] Tested in dev cluster

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes
