### PR TITLE
fix flaky forwarder-agent-test by waiting for logServer to have data

### DIFF
--- a/src/cmd/forwarder-agent/app/forwarder_agent_test.go
+++ b/src/cmd/forwarder-agent/app/forwarder_agent_test.go
@@ -372,6 +372,7 @@ var _ = Describe("App", func() {
 				<-otelTraceServer.requests
 			}
 			// test-title events
+			Eventually(otelLogsServer.requests).Should(HaveLen(1))
 			for len(otelLogsServer.requests) > 0 {
 				<-otelLogsServer.requests
 			}
@@ -386,16 +387,28 @@ var _ = Describe("App", func() {
 		DescribeTable("do not forward log nor event envelopes to otel metrics",
 			func(e *loggregator_v2.Envelope) {
 				ingressClient.Emit(e)
-				Consistently(otelMetricsServer.requests, 0.5).ShouldNot(Receive())
+				Consistently(otelMetricsServer.requests, 3).ShouldNot(Receive())
 			},
 			Entry("drops logs", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Log{}}),
 			Entry("drops events", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Event{}}),
+			Entry("drops timers", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Timer{}}),
+		)
+
+		DescribeTable("do not forward log nor events nor gauges envelopes to otel traces",
+			func(e *loggregator_v2.Envelope) {
+				ingressClient.Emit(e)
+				Consistently(otelTraceServer.requests, 3).ShouldNot(Receive())
+			},
+			Entry("drops logs", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Log{}}),
+			Entry("drops events", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Event{}}),
+			Entry("drops counters", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Event{}}),
+			Entry("drops gauges", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Event{}}),
 		)
 
 		DescribeTable("do not forward counters, gagues nor timers envelopes to otel logs",
 			func(e *loggregator_v2.Envelope) {
 				ingressClient.Emit(e)
-				Consistently(otelLogsServer.requests, 0.5).ShouldNot(Receive())
+				Consistently(otelLogsServer.requests, 3).ShouldNot(Receive())
 			},
 			Entry("drops counters", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Counter{}}),
 			Entry("drops gauges", &loggregator_v2.Envelope{Message: &loggregator_v2.Envelope_Gauge{}}),


### PR DESCRIPTION
…before purging

# Description

Please include a summary of the change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
