### PR TITLE
Add retry directly to https_batch implementation

### DIFF
--- a/src/pkg/egress/syslog/https_batch.go
+++ b/src/pkg/egress/syslog/https_batch.go
@@ -13,13 +13,68 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+type InternalRetryWriter interface {
+	ConfigureRetry(retryDuration RetryDuration, maxRetries int)
+}
+
+type Retryer struct {
+	retryDuration RetryDuration
+	maxRetries    int
+	binding       *URLBinding
+}
+
+func NewRetryer(
+	binding *URLBinding,
+	retryDuration RetryDuration,
+	maxRetries int,
+) *Retryer {
+	return &Retryer{
+		retryDuration: retryDuration,
+		maxRetries:    maxRetries,
+		binding:       binding,
+	}
+}
+
+func (r *Retryer) Retry(batch []byte, msgCount float64, function func([]byte, float64) error) error {
+	logTemplate := "failed to write to %s, retrying in %s, err: %s"
+
+	var err error
+
+	for i := 0; i <= r.maxRetries; i++ {
+		err = function(batch, msgCount)
+		if err == nil {
+			return nil // Success
+		}
+
+		if egress.ContextDone(r.binding.Context) {
+			log.Printf("Context cancelled for %s, aborting retries", r.binding.URL.Host)
+			return err
+		}
+
+		sleepDuration := r.retryDuration(i)
+		log.Printf(logTemplate, r.binding.URL.Host, sleepDuration, err)
+
+		time.Sleep(sleepDuration)
+	}
+
+	log.Printf("Exhausted retries for %s, dropping batch, err: %s", r.binding.URL.Host, err)
+	return err
+}
+
 type HTTPSBatchWriter struct {
 	HTTPSWriter
 	batchSize    int
 	sendInterval time.Duration
+	retryer      Retryer
 	msgChan      chan []byte
 	quit         chan struct{}
 	wg           sync.WaitGroup
+}
+
+// Also Marks that HTTPSBatchWriter implements the InternalRetryWriter interface
+func (w *HTTPSBatchWriter) ConfigureRetry(retryDuration RetryDuration, maxRetries int) {
+	w.retryer.retryDuration = retryDuration
+	w.retryer.maxRetries = maxRetries
 }
 
 type Option func(*HTTPSBatchWriter)
@@ -55,6 +110,9 @@ func NewHTTPSBatchWriter(
 			client:          client,
 			egressMetric:    egressMetric,
 			syslogConverter: c,
+		},
+		retryer: Retryer{
+			binding: binding,
 		},
 		batchSize:    256 * 1024,        // Default value
 		sendInterval: 1 * time.Second,   // Default value
@@ -97,10 +155,7 @@ func (w *HTTPSBatchWriter) startSender() {
 
 	sendBatch := func() {
 		if msgBatch.Len() > 0 {
-			err := w.sendHttpRequest(msgBatch.Bytes(), msgCount) // nolint:errcheck
-			if err != nil {
-				log.Printf("Failed to send batch, dropping batch of size %d , err: %s", int(msgCount), err)
-			}
+			w.retryer.Retry(msgBatch.Bytes(), msgCount, w.sendHttpRequest)
 			msgBatch.Reset()
 			msgCount = 0
 		}

--- a/src/pkg/egress/syslog/https_batch_retryer_test.go
+++ b/src/pkg/egress/syslog/https_batch_retryer_test.go
@@ -1,0 +1,87 @@
+package syslog_test
+
+import (
+	"errors"
+	"net/url"
+	"time"
+
+	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress/syslog"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/net/context"
+)
+
+var _ = Describe("Retryer", func() {
+	var (
+		retryer       *syslog.Retryer
+		retryAttempts int
+		binding       *syslog.URLBinding
+	)
+
+	BeforeEach(func() {
+		retryAttempts = 0
+		binding = &syslog.URLBinding{
+			URL: &url.URL{
+				Host: "test-host",
+			},
+			Context: context.Background(),
+		}
+		retryer = syslog.NewRetryer(
+			binding,
+			func(attempt int) time.Duration {
+				return 10 * time.Millisecond
+			}, 3)
+	})
+
+	It("retries the specified number of times on failure", func() {
+		err := retryer.Retry([]byte("test-batch"), 10, func(batch []byte, msgCount float64) error {
+			retryAttempts++
+			return errors.New("test error")
+		})
+
+		Expect(err).To(HaveOccurred())
+		Expect(retryAttempts).To(Equal(4)) // Retries up to maxRetries
+	})
+
+	It("stops retrying when the function succeeds", func() {
+		err := retryer.Retry([]byte("test-batch"), 10, func(batch []byte, msgCount float64) error {
+			retryAttempts++
+			if retryAttempts == 2 {
+				return nil // Succeed on the second attempt
+			}
+			return errors.New("test error")
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retryAttempts).To(Equal(2)) // Stops after success
+	})
+
+	It("stops retrying when the context is canceled", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		binding.Context = ctx
+		retryer = syslog.NewRetryer(
+			binding,
+			func(attempt int) time.Duration {
+				return 10 * time.Millisecond
+			}, 3)
+
+		cancel() // Cancel the context
+		err := retryer.Retry([]byte("test-batch"), 10, func(batch []byte, msgCount float64) error {
+			retryAttempts++
+			return errors.New("test error")
+		})
+		Eventually(err, time.Millisecond*100).Should(HaveOccurred())
+		Expect(retryAttempts).To(Equal(1)) // Only one attempt due to context cancellation
+	})
+
+	It("returns the last error after exhausting retries", func() {
+		finalError := errors.New("final error")
+		err := retryer.Retry([]byte("test-batch"), 10, func(batch []byte, msgCount float64) error {
+			retryAttempts++
+			return finalError
+		})
+
+		Expect(err).To(Equal(finalError))
+		Expect(retryAttempts).To(Equal(4)) // Retries up to maxRetries
+	})
+})

--- a/src/pkg/egress/syslog/https_batch_test.go
+++ b/src/pkg/egress/syslog/https_batch_test.go
@@ -59,6 +59,12 @@ var _ = Describe("HTTPS_batch", func() {
 			syslog.WithBatchSize(1000),
 			syslog.WithSendInterval(sendInterval),
 		)
+		rw := writer.(syslog.InternalRetryWriter)
+		rw.ConfigureRetry(
+			func(i int) time.Duration {
+				return 0
+			},
+			0) // No retries
 	})
 
 	AfterEach(func() {

--- a/src/pkg/egress/syslog/writer_factory.go
+++ b/src/pkg/egress/syslog/writer_factory.go
@@ -135,6 +135,13 @@ func (f WriterFactory) NewWriter(ub *URLBinding) (egress.WriteCloser, error) {
 		return nil, NewWriterFactoryErrorf(ub.URL, "unsupported protocol: %q", ub.URL.Scheme)
 	}
 
+	if rw, ok := w.(InternalRetryWriter); ok {
+		rw.ConfigureRetry(
+			ExponentialDuration,
+			maxRetries)
+		return w, nil
+	}
+
 	return NewRetryWriter(
 		ub,
 		ExponentialDuration,

--- a/src/pkg/egress/syslog/writer_factory_test.go
+++ b/src/pkg/egress/syslog/writer_factory_test.go
@@ -42,7 +42,7 @@ var _ = Describe("EgressFactory", func() {
 	})
 
 	Context("when the url begins with https and enables batching", func() {
-		It("returns an single https writer", func() {
+		It("returns an single https batch writer", func() {
 			url, err := url.Parse("https-batch://syslog.example.com")
 			Expect(err).ToNot(HaveOccurred())
 			urlBinding := &syslog.URLBinding{
@@ -52,10 +52,7 @@ var _ = Describe("EgressFactory", func() {
 			writer, err := f.NewWriter(urlBinding)
 			Expect(err).ToNot(HaveOccurred())
 
-			retryWriter, ok := writer.(*syslog.RetryWriter)
-			Expect(ok).To(BeTrue())
-
-			_, ok = retryWriter.Writer.(*syslog.HTTPSBatchWriter)
+			_, ok := writer.(*syslog.HTTPSBatchWriter)
 			Expect(ok).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
# Description

This change is necessary for http-batch to be reliable as the other services,
as there are no retries implemented at the moment, due to the way the retry logic is implemented for the other components.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes
