### PR TITLE
Handling counterfeiter in a pre v1.24 go world

### DIFF
--- a/src/pkg/egress/v1/envelope_writer.go
+++ b/src/pkg/egress/v1/envelope_writer.go
@@ -2,8 +2,7 @@ package v1
 
 import "github.com/cloudfoundry/sonde-go/events"
 
-//go:generate go tool counterfeiter -generate
-//counterfeiter:generate . EnvelopeWriter
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . EnvelopeWriter
 type EnvelopeWriter interface {
 	Write(event *events.Envelope)
 }

--- a/src/pkg/egress/v1/event_marshaller.go
+++ b/src/pkg/egress/v1/event_marshaller.go
@@ -15,7 +15,7 @@ type MetricClient interface {
 	NewCounter(name, helpText string, opts ...metrics.MetricOption) metrics.Counter
 }
 
-//counterfeiter:generate . BatchChainByteWriter
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . BatchChainByteWriter
 type BatchChainByteWriter interface {
 	Write(message []byte) (err error)
 }

--- a/src/pkg/egress/v2/envelope_writer.go
+++ b/src/pkg/egress/v2/envelope_writer.go
@@ -2,13 +2,12 @@ package v2
 
 import "code.cloudfoundry.org/go-loggregator/v10/rpc/loggregator_v2"
 
-//go:generate go tool counterfeiter -generate
-//counterfeiter:generate . Writer
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Writer
 type Writer interface {
 	Write(*loggregator_v2.Envelope) error
 }
 
-//counterfeiter:generate . EnvelopeProcessor
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . EnvelopeProcessor
 type EnvelopeProcessor interface {
 	Process(*loggregator_v2.Envelope) error
 }

--- a/src/pkg/egress/v2/transponder.go
+++ b/src/pkg/egress/v2/transponder.go
@@ -9,12 +9,12 @@ import (
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/plumbing/batching"
 )
 
-//counterfeiter:generate . Nexter
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Nexter
 type Nexter interface {
 	TryNext() (*loggregator_v2.Envelope, bool)
 }
 
-//counterfeiter:generate . BatchWriter
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . BatchWriter
 type BatchWriter interface {
 	Write(msgs []*loggregator_v2.Envelope) error
 }

--- a/src/pkg/ingress/bindings/binding_fetcher.go
+++ b/src/pkg/ingress/bindings/binding_fetcher.go
@@ -18,10 +18,9 @@ type Metrics interface {
 	NewCounter(name, helpText string, opts ...metrics.MetricOption) metrics.Counter
 }
 
-//go:generate go tool counterfeiter -generate
-
 // Getter is configured to fetch HTTP responses
-//counterfeiter:generate . Getter
+//
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Getter
 type Getter interface {
 	Get() ([]binding.Binding, error)
 }

--- a/src/pkg/ingress/bindings/filtered_binding_fetcher.go
+++ b/src/pkg/ingress/bindings/filtered_binding_fetcher.go
@@ -14,7 +14,7 @@ import (
 
 var allowedSchemes = []string{"syslog", "syslog-tls", "https", "https-batch"}
 
-//counterfeiter:generate . IPChecker
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . IPChecker
 type IPChecker interface {
 	ResolveAddr(host string) (net.IP, error)
 	CheckBlacklist(ip net.IP) error


### PR DESCRIPTION
# Description

[Counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) mock generation used is not compatible with the version of go we are using (1.23). This PR aligns the generation of the mocks with our version of go. All this is explained better [here](https://github.com/maxbrunsfeld/counterfeiter?tab=readme-ov-file#using-counterfeiter) under "If you are working with go 1.23 or earlier".

This commit should be reverted when we update go to 1.24+. This will allow Counterfeiter to use the new tool generation syntax.
 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
