### PR TITLE
Move to golangci v2

### DIFF
--- a/scripts/subtests/lint
+++ b/scripts/subtests/lint
@@ -9,7 +9,7 @@ set +e
 golangci_lint_executable=$(which golangci-lint)
 set -e
 if [ -z "${golangci_lint_executable}" ] || [ ! -x "${golangci_lint_executable}" ]; then
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 fi
 
 pushd "${SCRIPT_DIR}/../../src" > /dev/null

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,8 +1,8 @@
+version: "2"
 run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
+  # Timeout full work, e.g. 30s, 5m.
+  # Default: none
   timeout: 5m
-
 linters:
   enable:
     # Checks for non-ASCII identifiers
@@ -11,15 +11,31 @@ linters:
     - gocyclo
     # Inspects source code for security problems.
     - gosec
-
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Exclude some linters from running on helheim generated file.
+      - linters:
+          - unused
+        path: pkg/egress/v2/helheim_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   # Disable max issues per linter.
   max-issues-per-linter: 0
   # Disable max same issues.
   max-same-issues: 0
-
-  exclude-rules:
-    # Exclude some linters from running on helheim generated file.
-    - path: pkg/egress/v2/helheim_test\.go
-      linters:
-        - unused
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/src/cmd/loggregator-agent/app/app_v1.go
+++ b/src/cmd/loggregator-agent/app/app_v1.go
@@ -84,7 +84,7 @@ func (a *AppV1) Start() {
 		a.metricClient,
 	)
 	if err != nil {
-		log.Panic(fmt.Errorf("Failed to listen on %s: %s", agentAddress, err))
+		log.Panic(fmt.Errorf("failed to listen on %s: %s", agentAddress, err))
 	}
 
 	log.Printf("agent v1 API started on addr %s", agentAddress)

--- a/src/cmd/loggregator-agent/app/app_v2.go
+++ b/src/cmd/loggregator-agent/app/app_v2.go
@@ -18,7 +18,6 @@ import (
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/diodes"
 	egress "code.cloudfoundry.org/loggregator-agent-release/src/pkg/egress/v2"
 	ingress "code.cloudfoundry.org/loggregator-agent-release/src/pkg/ingress/v2"
-	v2 "code.cloudfoundry.org/loggregator-agent-release/src/pkg/ingress/v2"
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/plumbing"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -137,7 +136,7 @@ func (a *AppV2) Start() {
 	var es envelopeSetter
 	es = envelopeBuffer
 	if a.config.LogsDisabled {
-		es = v2.NewFilteringSetter(envelopeBuffer)
+		es = ingress.NewFilteringSetter(envelopeBuffer)
 	}
 
 	rx := ingress.NewReceiver(es, ingressMetric, originMappings)

--- a/src/cmd/loggregator-agent/app/config.go
+++ b/src/cmd/loggregator-agent/app/config.go
@@ -66,7 +66,7 @@ func LoadConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg.RouterAddrWithAZ = strings.Replace(cfg.RouterAddrWithAZ, "@", "-", -1)
+	cfg.RouterAddrWithAZ = strings.ReplaceAll(cfg.RouterAddrWithAZ, "@", "-")
 
 	return &cfg, nil
 }

--- a/src/cmd/syslog-agent/app/config.go
+++ b/src/cmd/syslog-agent/app/config.go
@@ -140,7 +140,7 @@ func convertCipherStringToInt(cipherStrs []string, cipherMap map[string]uint16) 
 			for key := range cipherMap {
 				supportedCipherSuites = append(supportedCipherSuites, key)
 			}
-			return nil, fmt.Errorf("Invalid cipher string configuration: %s, please choose from %v", cipher, supportedCipherSuites)
+			return nil, fmt.Errorf("invalid cipher string configuration: %s, please choose from %v", cipher, supportedCipherSuites)
 		}
 	}
 

--- a/src/cmd/syslog-agent/app/syslog_agent_mtls_test.go
+++ b/src/cmd/syslog-agent/app/syslog_agent_mtls_test.go
@@ -285,8 +285,8 @@ func (f *fakeBindingCache) startTLS(testCerts *testhelper.TestCerts) {
 	Expect(err).ToNot(HaveOccurred())
 
 	f.Server = httptest.NewUnstartedServer(f)
-	f.Server.TLS = tlsConfig
-	f.Server.StartTLS()
+	f.TLS = tlsConfig
+	f.StartTLS()
 }
 
 func (f *fakeBindingCache) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
+++ b/src/cmd/syslog-binding-cache/app/syslog_binding_cache_test.go
@@ -289,8 +289,8 @@ func (f *fakeCC) startTLS(testCerts *testhelper.TestCerts) {
 	Expect(err).ToNot(HaveOccurred())
 
 	f.Server = httptest.NewUnstartedServer(f)
-	f.Server.TLS = tlsConfig
-	f.Server.StartTLS()
+	f.TLS = tlsConfig
+	f.StartTLS()
 }
 
 func (f *fakeCC) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/src/internal/testservers/agent.go
+++ b/src/internal/testservers/agent.go
@@ -11,7 +11,10 @@ import (
 	"code.cloudfoundry.org/loggregator-agent-release/src/cmd/loggregator-agent/app"
 	"code.cloudfoundry.org/loggregator-agent-release/src/internal/testhelper"
 
+	// . imports are common usage for ginkgo
+	//nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
+	//nolint:staticcheck
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 )

--- a/src/pkg/egress/syslog/https.go
+++ b/src/pkg/egress/syslog/https.go
@@ -91,11 +91,11 @@ func (*HTTPSWriter) sanitizeError(u *url.URL, err error) error {
 	}
 
 	if user := u.User.Username(); user != "" {
-		err = errors.New(strings.Replace(err.Error(), user, "<REDACTED>", -1))
+		err = errors.New(strings.ReplaceAll(err.Error(), user, "<REDACTED>"))
 	}
 
 	if p, ok := u.User.Password(); ok {
-		err = errors.New(strings.Replace(err.Error(), p, "<REDACTED>", -1))
+		err = errors.New(strings.ReplaceAll(err.Error(), p, "<REDACTED>"))
 	}
 	return err
 }

--- a/src/pkg/egress/syslog/tcp.go
+++ b/src/pkg/egress/syslog/tcp.go
@@ -126,7 +126,7 @@ func (w *TCPWriter) Close() error {
 }
 
 func removeNulls(msg []byte) []byte {
-	return bytes.Replace(msg, []byte{0}, nil, -1)
+	return bytes.ReplaceAll(msg, []byte{0}, nil)
 }
 
 func appendNewline(msg []byte) []byte {
@@ -146,7 +146,7 @@ func generateProcessID(sourceType, sourceInstance string) string {
 		}
 		tmp := make([]byte, 0, 3+len(sourceType)+len(sourceInstance))
 		tmp = append(tmp, '[')
-		tmp = append(tmp, []byte(strings.Replace(sourceType, " ", "-", -1))...)
+		tmp = append(tmp, []byte(strings.ReplaceAll(sourceType, " ", "-"))...)
 		tmp = append(tmp, '/')
 		tmp = append(tmp, []byte(sourceInstance)...)
 		tmp = append(tmp, ']')

--- a/src/pkg/egress/v1/eventwriter.go
+++ b/src/pkg/egress/v1/eventwriter.go
@@ -50,8 +50,8 @@ func (e *EventWriter) SetWriter(writer EnvelopeWriter) {
 	e.writer = writer
 }
 
-var ErrorMissingOrigin = errors.New("Event not emitted due to missing origin information")
-var ErrorUnknownEventType = errors.New("Cannot create envelope for unknown event type")
+var ErrorMissingOrigin = errors.New("event not emitted due to missing origin information")
+var ErrorUnknownEventType = errors.New("cannot create envelope for unknown event type")
 
 func wrap(event events.Event, origin string) (*events.Envelope, error) {
 	if origin == "" {

--- a/src/pkg/ingress/v1/event_unmarshaller.go
+++ b/src/pkg/ingress/v1/event_unmarshaller.go
@@ -13,7 +13,7 @@ type EnvelopeWriter interface {
 }
 
 var (
-	errInvalidEnvelope = errors.New("Invalid Envelope")
+	errInvalidEnvelope = errors.New("invalid Envelope")
 )
 
 // An EventUnmarshaller is an self-instrumenting tool for converting Protocol


### PR DESCRIPTION
# Description

Move to golangci-lint v2.

Changes:

* Accept [QF1004](https://staticcheck.dev/docs/checks/#QF1004): Change `Replace` to `ReplaceAll` where sensible
* Accept [QF1008](https://staticcheck.dev/docs/checks/#QF1008): Omit an embedded field
* Accept [ST1019](https://staticcheck.dev/docs/checks/#ST1019): `code.cloudfoundry.org/loggregator-agent-release/src/pkg/ingress/v2` had been imported twice
* Accept [ST1005](https://staticcheck.dev/docs/checks/#ST1005): to have nicer logs

Noteworthy changes in golangci-lint v2:

* New config format (migrated with `migrate` command)
* Default timeout is now 0 instead of 1 minute. See [here](https://github.com/golangci/golangci-lint/pull/5470/commits/d3bf353d4531c824201394821f0119a690a01519#r1968522617) for rationale. Kept ours unchanged for now.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes