### PR TITLE
Truncate counter metric with fractional part instead of dropping it

### DIFF
--- a/src/pkg/otelcolclient/otelcolclient.go
+++ b/src/pkg/otelcolclient/otelcolclient.go
@@ -51,6 +51,12 @@ func NewGRPCWriter(addr string, tlsConfig *tls.Config, l *log.Logger) (*GRPCWrit
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if cancel != nil {
+			cancel()
+		}
+	}()
+
 	w := &GRPCWriter{
 		msc:    colmetricspb.NewMetricsServiceClient(cc),
 		tsc:    coltracepb.NewTraceServiceClient(cc),
@@ -59,6 +65,7 @@ func NewGRPCWriter(addr string, tlsConfig *tls.Config, l *log.Logger) (*GRPCWrit
 		cancel: cancel,
 		l:      l,
 	}
+	cancel = nil
 	return w, nil
 }
 

--- a/src/pkg/scraper/scraper.go
+++ b/src/pkg/scraper/scraper.go
@@ -2,13 +2,14 @@ package scraper
 
 import (
 	"fmt"
-	"github.com/prometheus/common/model"
 	"io"
 	"log"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/prometheus/common/model"
 
 	"code.cloudfoundry.org/go-loggregator/v10"
 	metrics "code.cloudfoundry.org/go-metric-registry"
@@ -221,9 +222,6 @@ func (s *Scraper) emitUntyped(sourceID, instanceID, name string, tags map[string
 
 func (s *Scraper) emitCounter(sourceID, instanceID, name string, tags map[string]string, metric *io_prometheus_client.Metric) {
 	val := metric.GetCounter().GetValue()
-	if val != float64(uint64(val)) {
-		return //the counter contains a fractional value
-	}
 
 	s.metricsEmitter.EmitCounter(
 		name,

--- a/src/pkg/scraper/scraper_test.go
+++ b/src/pkg/scraper/scraper_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Scraper", func() {
 			))
 		})
 
-		It("ignores counter metrics with float values", func() {
+		It("truncates counter metrics with float values to uint64", func() {
 			tc := setup(scraper.Target{
 				ID:         "some-id",
 				InstanceID: "some-instance-id",
@@ -168,6 +168,7 @@ var _ = Describe("Scraper", func() {
 
 			Expect(tc.metricEmitter.envelopes).To(ConsistOf(
 				buildCounter("source-1", "some-instance-id", "counter_int", 1, nil),
+				buildCounter("source-2", "some-instance-id", "counter_float", 2, nil),
 			))
 		})
 	})


### PR DESCRIPTION
We observed otelcol_process_cpu_seconds_total was available intermittently. This is a counter metric, but most time, its value has fractional part, thus dropped by prom-scraper. The solution is to truncate it to uint64 instead of dropping it.

# Description

We observed otelcol_process_cpu_seconds_total was available intermittently. This is a counter metric, but most time, its value has fractional part, thus dropped by prom-scraper. The solution is to truncate it to uint64 instead of dropping it. And lint fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
