### PR TITLE
Add benchmark test and optimize byte slice reuse in network_reader

### DIFF
--- a/src/pkg/ingress/v1/network_reader.go
+++ b/src/pkg/ingress/v1/network_reader.go
@@ -3,12 +3,19 @@ package v1
 import (
 	"log"
 	"net"
+	"sync"
 
 	metrics "code.cloudfoundry.org/go-metric-registry"
 
 	gendiodes "code.cloudfoundry.org/go-diodes"
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/diodes"
 )
+
+var packetPool = sync.Pool{
+	New: func() any {
+		return new([65535]byte)
+	},
+}
 
 type ByteArrayWriter interface {
 	Write(message []byte)
@@ -58,17 +65,16 @@ func NewNetworkReader(
 }
 
 func (nr *NetworkReader) StartReading() {
-	readBuffer := make([]byte, 65535) //buffer with size = max theoretical UDP size
 	for {
-		readCount, _, err := nr.connection.ReadFrom(readBuffer)
+		bufPtr := packetPool.Get().(*[65535]byte)
+		readCount, _, err := nr.connection.ReadFrom(bufPtr[:])
 		if err != nil {
 			log.Printf("Error while reading: %s", err)
+			packetPool.Put(bufPtr)
 			return
 		}
-		readData := make([]byte, readCount)
-		copy(readData, readBuffer[:readCount])
 
-		nr.buffer.Set(readData)
+		nr.buffer.Set(bufPtr[:readCount])
 	}
 }
 
@@ -77,6 +83,11 @@ func (nr *NetworkReader) StartWriting() {
 		data := nr.buffer.Next()
 		nr.rxMsgCount(1)
 		nr.writer.Write(data)
+
+		if cap(data) == 65535 {
+			fullSlice := data[:65535]
+			packetPool.Put((*[65535]byte)(fullSlice))
+		}
 	}
 }
 

--- a/src/pkg/ingress/v1/network_reader.go
+++ b/src/pkg/ingress/v1/network_reader.go
@@ -11,9 +11,11 @@ import (
 	"code.cloudfoundry.org/loggregator-agent-release/src/pkg/diodes"
 )
 
+const bufferSize int = 65535
+
 var packetPool = sync.Pool{
 	New: func() any {
-		return new([65535]byte)
+		return new([bufferSize]byte)
 	},
 }
 
@@ -66,7 +68,7 @@ func NewNetworkReader(
 
 func (nr *NetworkReader) StartReading() {
 	for {
-		bufPtr := packetPool.Get().(*[65535]byte)
+		bufPtr := packetPool.Get().(*[bufferSize]byte)
 		readCount, _, err := nr.connection.ReadFrom(bufPtr[:])
 		if err != nil {
 			log.Printf("Error while reading: %s", err)
@@ -84,9 +86,9 @@ func (nr *NetworkReader) StartWriting() {
 		nr.rxMsgCount(1)
 		nr.writer.Write(data)
 
-		if cap(data) == 65535 {
-			fullSlice := data[:65535]
-			packetPool.Put((*[65535]byte)(fullSlice))
+		if cap(data) == bufferSize {
+			fullSlice := data[:bufferSize]
+			packetPool.Put((*[bufferSize]byte)(fullSlice))
 		}
 	}
 }

--- a/src/pkg/ingress/v1/network_reader_benchmark_test.go
+++ b/src/pkg/ingress/v1/network_reader_benchmark_test.go
@@ -1,0 +1,99 @@
+package v1_test
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	metricsHelpers "code.cloudfoundry.org/go-metric-registry/testhelpers"
+	ingress "code.cloudfoundry.org/loggregator-agent-release/src/pkg/ingress/v1"
+)
+
+type benchmarkWriter struct {
+	ch chan struct{}
+}
+
+func (w *benchmarkWriter) Write(p []byte) {
+	w.ch <- struct{}{}
+}
+
+func getFreePort(b *testing.B) int {
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer conn.Close()
+	_, addrPort, err := net.SplitHostPort(conn.LocalAddr().String())
+	if err != nil {
+		b.Fatal(err)
+	}
+	port, err := strconv.Atoi(addrPort)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return port
+}
+
+func benchmarkNetworkReaderWithSize(b *testing.B, size int) {
+	port := getFreePort(b)
+	address := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	
+	metricClient := metricsHelpers.NewMetricsRegistry()
+	writer := &benchmarkWriter{
+		ch: make(chan struct{}, 1),
+	}
+
+	reader, err := ingress.NewNetworkReader(address, writer, metricClient)
+	if err != nil {
+		b.Fatalf("failed to create network reader: %s", err)
+	}
+	defer reader.Stop()
+
+	go reader.StartReading()
+	go reader.StartWriting()
+
+	connection, err := net.Dial("udp", address)
+	if err != nil {
+		b.Fatalf("failed to dial: %s", err)
+	}
+	defer connection.Close()
+
+	packet := make([]byte, size)
+	for i := range packet {
+		packet[i] = 'a'
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := connection.Write(packet)
+		if err != nil {
+			b.Fatalf("failed to write: %s", err)
+		}
+		<-writer.ch
+	}
+}
+
+func BenchmarkNetworkReader_8KB(b *testing.B) {
+	benchmarkNetworkReaderWithSize(b, 8192)
+}
+
+func BenchmarkNetworkReader_16KB(b *testing.B) {
+	benchmarkNetworkReaderWithSize(b, 16384)
+}
+
+func BenchmarkNetworkReader_32KB(b *testing.B) {
+	benchmarkNetworkReaderWithSize(b, 32768)
+}
+
+func BenchmarkNetworkReader_48KB(b *testing.B) {
+	benchmarkNetworkReaderWithSize(b, 49152)
+}
+
+func BenchmarkNetworkReader_64KB(b *testing.B) {
+	benchmarkNetworkReaderWithSize(b, 65507)  //65535 is the max UDP size, but we need to leave room for the headers: 20 for IPv4 and 8 for UDP
+}


### PR DESCRIPTION
### Problem
During performance testing of the gorouter with the udp-forwarder configured, we observed CPU consumption spikes in the udp-forwarder when the gorouter exceeds 1,500 requests per second. Profiling a benchmark revealed that the garbage collector consumes the majority of the CPU time because `NetworkReader` allocates a new byte slice for every single read.

### Solution
This PR updates `NetworkReader` to use a `sync.Pool` for byte slice allocation, allowing the slices to be reused rather than constantly reallocated.

### Impact
This change flattens memory usage and prevents the garbage collector from being overwhelmed when a large number of UDP messages are sent to the forwarder, resolving the CPU spikes under high load.

## Benchmark comparison

```shell
benchstat old.bench new.bench
goos: linux
goarch: amd64
pkg: code.cloudfoundry.org/loggregator-agent-release/src/pkg/ingress/v1
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
                      │  old.bench  │              new.bench              │
                      │   sec/op    │    sec/op     vs base               │
NetworkReader_8KB-16    33.25µ ± 5%   24.27µ ± 11%  -26.98% (p=0.002 n=6)
NetworkReader_16KB-16   33.34µ ± 3%   22.15µ ± 22%  -33.55% (p=0.002 n=6)
NetworkReader_32KB-16   42.19µ ± 3%   23.77µ ±  9%  -43.66% (p=0.002 n=6)
NetworkReader_48KB-16   53.80µ ± 3%   28.38µ ±  5%  -47.26% (p=0.002 n=6)
NetworkReader_64KB-16   60.46µ ± 4%   30.75µ ± 21%  -49.13% (p=0.002 n=6)
geomean                 43.30µ        25.67µ        -40.70%

                      │  old.bench   │             new.bench             │
                      │     B/op     │    B/op     vs base               │
NetworkReader_8KB-16     8284.0 ± 0%   125.0 ± 3%  -98.49% (p=0.002 n=6)
NetworkReader_16KB-16   16476.0 ± 0%   125.5 ± 3%  -99.24% (p=0.002 n=6)
NetworkReader_32KB-16   32860.0 ± 0%   124.5 ± 4%  -99.62% (p=0.002 n=6)
NetworkReader_48KB-16   49245.0 ± 0%   122.0 ± 2%  -99.75% (p=0.002 n=6)
NetworkReader_64KB-16   65629.0 ± 0%   123.5 ± 4%  -99.81% (p=0.002 n=6)
geomean                 26.42Ki        124.1       -99.54%

                      │ old.bench  │             new.bench              │
                      │ allocs/op  │ allocs/op   vs base                │
NetworkReader_8KB-16    5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=6) ¹
NetworkReader_16KB-16   5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=6) ¹
NetworkReader_32KB-16   5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=6) ¹
NetworkReader_48KB-16   5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=6) ¹
NetworkReader_64KB-16   5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                 5.000        5.000       +0.00%
¹ all samples are equal
```


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
